### PR TITLE
docs: ajouter rapport d'évaluation de l'état de développement (2026-03-09)

### DIFF
--- a/docs/rapport_datedujour.md
+++ b/docs/rapport_datedujour.md
@@ -1,0 +1,113 @@
+# Rapport d'évaluation de l'état de développement — OpenIndex
+
+_Date du rapport : 2026-03-09_
+
+## 1) Périmètre et méthode
+
+Ce rapport évalue l'état de développement **uniquement à partir de la documentation présente à la racine** du dépôt (`README.md`, `CHANGELOG.md`, `PROJET.md`, `CI-CD.md`, `ROADMAP.md`, `TODO.md`, `README.stack.md`).
+
+Méthode appliquée :
+- comparaison des objectifs annoncés vs avancement déclaré ;
+- analyse de cohérence entre documents ;
+- identification des risques projet ;
+- proposition de priorités d'exécution court terme.
+
+## 2) Synthèse exécutive
+
+OpenIndex se situe à un stade **intermédiaire** :
+- la **migration d'architecture** vers FastAPI + frontend léger + PostgreSQL est documentée comme réalisée ;
+- la **vision produit** est claire et ambitieuse ;
+- l'**industrialisation** (tests réellement finalisés, monitoring opérationnel, preuves de production) reste partiellement contradictoire selon les documents ;
+- le **pilotage** souffre d'un écart entre roadmap macro (progression très faible) et TODO (grand nombre d'items marqués terminés, parfois avec commits `TBD`).
+
+Conclusion : le projet paraît **techniquement bien orienté**, mais nécessite une **consolidation de gouvernance documentaire et de traçabilité** avant d'être considéré comme stable en production.
+
+## 3) Points forts observés
+
+1. **Architecture cible moderne et pertinente**
+   - séparation des responsabilités (crawler, API, frontend, base) ;
+   - stack alignée sur des besoins de performance et de scalabilité ;
+   - prise en compte explicite du temps réel (WebSocket), de la déduplication et des contraintes volumétriques SMB.
+
+2. **Documentation stratégique riche**
+   - présence d'une vision produit (`PROJET.md`) ;
+   - roadmap structurée par phases (`ROADMAP.md`) ;
+   - journal de changements (`CHANGELOG.md`) ;
+   - cadrage CI/CD (`CI-CD.md`) ;
+   - pilotage opérationnel via TODO détaillé (`TODO.md`).
+
+3. **Orientation DevOps présente**
+   - logique CI/CD décrite ;
+   - architecture conteneurisée ;
+   - mention de monitoring, healthchecks, performance, déploiement modulaire.
+
+## 4) Signaux de risque / incohérences
+
+### 4.1 Incohérences d'avancement
+
+- `ROADMAP.md` annonce une progression globale très faible (~3%).
+- `README.md` présente un résumé de progression autour de 23%.
+- `TODO.md` marque de nombreuses tâches en ✅, mais plusieurs références de commits restent `TBD`.
+
+➡️ Risque : difficulté à déterminer un **avancement factuel** et donc à prioriser correctement.
+
+### 4.2 Écart entre architecture "actuelle" selon les fichiers
+
+- Certains documents décrivent la cible moderne FastAPI/VanillaJS.
+- `README.stack.md` décrit encore une Web UI Streamlit dans la stack.
+
+➡️ Risque : ambiguïté pour nouveaux contributeurs et risque d'erreur de déploiement.
+
+### 4.3 Dette de validation et preuve de qualité
+
+- Le changelog et le TODO mentionnent des tests, monitoring et optimisations terminés ou en cours.
+- L'absence de références systématiques et homogènes (commits non renseignés) limite la vérifiabilité documentaire.
+
+➡️ Risque : perception de maturité supérieure à la maturité réelle.
+
+## 5) Niveau de maturité estimé (sur base documentaire)
+
+- **Vision produit** : 4/5 (claire et détaillée)
+- **Architecture technique** : 4/5 (pertinente, modernisée)
+- **Exécution / livraison** : 2.5/5 (avancement documenté mais hétérogène)
+- **Qualité / traçabilité** : 2/5 (preuves incomplètes, statuts contradictoires)
+- **Préparation production** : 2.5/5 (fondations bonnes, validation à renforcer)
+
+**Maturité globale estimée : 3/5 (projet prometteur mais encore en phase de consolidation).**
+
+## 6) Recommandations prioritaires
+
+### Priorité 1 — Réconciliation documentaire (immédiat)
+
+- Désigner une **source de vérité** pour le statut (ex. `TODO.md` ou `ROADMAP.md`).
+- Aligner les pourcentages d'avancement entre README / ROADMAP / TODO.
+- Remplacer tous les `TBD` par des commits réels ou repasser les tâches en "à faire".
+
+### Priorité 2 — Clarifier l'architecture officielle
+
+- Mettre à jour `README.stack.md` pour refléter sans ambiguïté la stack actuelle (ou marquer explicitement la doc comme "legacy").
+- Ajouter un tableau "Architecture actuelle vs architecture historique".
+
+### Priorité 3 — Renforcer la preuve de qualité
+
+- Documenter un "Definition of Done" minimal par tâche (code + test + preuve CI + doc).
+- Publier un état des tests (unitaires/intégration/E2E) avec couverture réelle et date de mesure.
+
+### Priorité 4 — Stabilisation orientée deadline
+
+- Isoler les livrables indispensables avant la deadline mentionnée dans TODO.
+- Geler les features non critiques et prioriser robustesse : fiabilité crawler, cohérence API, UX minimale exploitable, supervision.
+
+## 7) Plan d'action concret (7 jours)
+
+- **J1** : audit documentaire + décision source de vérité.
+- **J2** : mise à jour synchronisée README / ROADMAP / TODO.
+- **J3** : clarification stack et nettoyage des docs "legacy".
+- **J4** : exécution et publication d'un lot de tests reproductibles.
+- **J5** : validation CI/CD de bout en bout + checklist release.
+- **J6** : correctifs de stabilisation (bugfix uniquement).
+- **J7** : revue finale et préparation livraison.
+
+## 8) Conclusion
+
+Le socle technique décrit est solide et cohérent avec une ambition de production. Néanmoins, l'état réel de développement est aujourd'hui **moins lisible que ce qu'il devrait être** à cause d'incohérences de suivi. En traitant rapidement la traçabilité documentaire et la validation qualité, OpenIndex peut passer d'un projet "en transformation" à un projet "prêt à industrialiser".


### PR DESCRIPTION
### Motivation
- Produire une évaluation de l'état de développement à partir des fichiers `.md` à la racine et déposer le rapport dans `docs/rapport_datedujour.md` conformément à la demande.

### Description
- Ajout du fichier `docs/rapport_datedujour.md` qui contient : périmètre/méthode, synthèse exécutive, points forts, incohérences/risques, estimation de maturité, recommandations prioritaires et plan d'action 7 jours, basé sur `README.md`, `CHANGELOG.md`, `PROJET.md`, `CI-CD.md`, `ROADMAP.md`, `TODO.md` et `README.stack.md`, puis commité.

### Testing
- Vérification Git via `git status --short` et inspection du contenu avec `nl -ba docs/rapport_datedujour.md` pour valider la présence et le contenu du fichier, les vérifications ont réussi et aucun test applicatif n'a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedf9960b0832e857c65c98632be8a)