### PR TITLE
docs: synchroniser la proposition J2 entre README, ROADMAP et TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,5 @@ Ce projet est sous licence [MIT](LICENSE).
 ---
 
 **Développé avec ❤️ pour l'archivage professionnel efficace**
+
+Paragraphe de mise à jour J2 : cette révision documente une proposition J2 commune entre README, ROADMAP et TODO afin d'assurer un suivi synchronisé des priorités, des critères de validation et du reporting quotidien.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,11 +24,13 @@ L'architecture a été migrée vers une stack moderne microservices avec :
   - ✅ Documentation mise à jour (README, CHANGELOG, ROADMAP)
 
 - **Jour 2 (Mardi 27/02) - 7h** :
+  - [x] Proposition J2 validée : plan de test et critères d'acceptation synchronisés (README / ROADMAP / TODO)
   - [ ] Tests automatisés FastAPI (pytest + pytest-asyncio)
   - [ ] Tests frontend VanillaJS (unit tests + integration)
   - [ ] Validation WebSocket monitoring temps réel
   - [ ] Tests charges API (1000+ requêtes concurrentes)
   - [ ] Optimisation performance base de données
+  - [ ] Livraison de fin de journée : état d'avancement, risques et décisions documentées
 
 - **Jour 3 (Mercredi 28/02) - 7h** :
   - [ ] Configuration CI/CD complète (build + test + deploy)

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,16 @@ Ce fichier contient la liste des tâches à effectuer pour le projet OpenIndex, 
 
 ## 🎯 Priorités Avant 19 Mars 2026 (Deadline DGS)
 
+## 🗓️ Proposition J2 (mise à jour synchronisée)
+
+Objectif J2 : verrouiller un plan réaliste et partagé pour les tests de stabilisation de la stack moderne, avec une trace unique dans README / ROADMAP / TODO.
+
+- [x] Aligner les objectifs J2 entre les 3 documents de pilotage
+- [ ] Exécuter les tests API prioritaires (smoke + régression endpoints critiques)
+- [ ] Exécuter les tests frontend prioritaires (navigation, dashboard, doublons)
+- [ ] Valider le monitoring WebSocket en conditions multi-clients
+- [ ] Publier le bilan J2 en fin de journée (résultats, blocages, arbitrages)
+
 ### � **Phase 1 : Stabilisation Architecture Moderne (Semaine 26 Février - 5 Mars 2026)**
 
 #### ✅ **Terminées - 26 Février 2026**


### PR DESCRIPTION
### Motivation
- Verrouiller et centraliser la proposition J2 pour garantir un pilotage unique et cohérent entre la vision (README), la planification (ROADMAP) et l'exécution (TODO). 
- Clarifier les priorités de tests (API, frontend, WebSocket, performance BDD) et définir un livrable de reporting de fin de journée.

### Description
- Ajout d'un item validé de cadrage et d'un livrable de fin de journée dans `ROADMAP.md` pour la journée J2. 
- Ajout de la section `Proposition J2 (mise à jour synchronisée)` dans `TODO.md` avec l'objectif J2 et une checklist opérationnelle (API, frontend, WebSocket, bilan). 
- Ajout d'un paragraphe récapitulatif en fin de `README.md` décrivant la mise à jour J2 et la synchronisation documentaire. 
- Tous les changements ont été commités dans un seul commit de documentation.

### Testing
- Vérification des diffs et du contenu modifié via `git diff -- README.md ROADMAP.md TODO.md` et inspection des fichiers mise à jour, réussite constatée. 
- Vérification de l'état du dépôt via `git status --short` et commit avec `git commit -m "docs: synchroniser la proposition J2 sur README ROADMAP TODO"`, opération réussie. 
- Validation automatisée minimale effectuée (scripts Python utilisés pour insérer les sections et `apply_patch` pour les modifications), toutes les opérations ont abouti sans erreur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee7173bc4832e8b77e83a92eceee8)