### PR TITLE
docs: clarify modern stack and clean legacy documentation (J3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,26 +238,10 @@ docker-compose -f docker-compose.modern.yml logs api
 docker-compose -f docker-compose.modern.yml build --no-cache
 ```
 
-# Installer les dépendances
-pip install -r requirements.txt
+### Clarification documentation
+- La stack de référence est décrite dans `README.stack.md` (FastAPI + frontend statique + PostgreSQL).
+- Les instructions Streamlit historiques sont considérées **legacy** et ne doivent plus être utilisées pour un nouveau déploiement.
 
-# Lancer l'interface web
-streamlit run src/web_interface_v2.py
-```
-
-### Configuration du Logging
-Le système utilise une rotation automatique des logs avec compression :
-- **Rotation** : Fichiers tournés à 5MB (10MB par défaut)
-- **Compression** : Fichiers de rotation compressés en GZIP
-- **Rétention** : 10 rotations conservées (configurable)
-- **Emplacement** : Tous les logs sont stockés dans le répertoire `/logs/`
-
-Les logs sont automatiquement gérés sans intervention manuelle.
-
-### Accès
-- **Interface Web** : http://localhost:8502
-- **Documentation** : [PROJET.md](PROJET.md)
-- **Tâches en cours** : [TODO.md](TODO.md)
 
 ## 📋 État du Projet
 

--- a/README.stack.md
+++ b/README.stack.md
@@ -1,191 +1,81 @@
-# OpenIndex Stack - Architecture Microservices
+# OpenIndex Stack - Architecture de référence
 
-## 🏗️ **Architecture**
+> Statut : **document de référence actuel** (stack moderne FastAPI + Frontend statique + PostgreSQL).
+>
+> Les éléments basés sur Streamlit / `deploy-stack.sh` / `docker-compose.stack.yml` sont désormais considérés comme **legacy** et ne doivent plus être utilisés pour les nouveaux déploiements.
+
+## 🧭 Clarification de stack
+
+| Domaine | Stack actuelle (à utiliser) | Stack legacy (historique) |
+|---|---|---|
+| API backend | FastAPI (`src/api/main.py`) | Intégration directe via UI Streamlit |
+| Frontend | HTML/JS statique (`frontend/index.html`) servi par Nginx | Streamlit (`src/web_interface_v2.py`) |
+| Orchestration | `docker-compose.modern.yml` + `deploy-modern.sh` | `docker-compose.stack.yml` + `deploy-stack.sh` |
+| Dockerfiles principaux | `Dockerfile.api`, `Dockerfile.frontend`, `Dockerfile.crawler` | `Dockerfile.web` |
+| Documentation de démarrage | `README.md` | anciens guides de stack microservices |
+
+## 🏗️ Architecture actuelle
 
 ```mermaid
 graph TB
-    subgraph "OpenIndex Microservices"
-        A[PostgreSQL<br/>Database<br/>Port: 5432]
-        B[Crawler<br/>Python<br/>Workers: 4]
-        C[Web UI<br/>Streamlit<br/>Port: 8502]
-        D[pgAdmin<br/>Admin<br/>Port: 5050]
-        E[Grafana<br/>Monitoring<br/>Port: 3000]
+    subgraph "OpenIndex Moderne"
+        API[FastAPI<br/>Port: 8000]
+        FE[Frontend statique<br/>Nginx<br/>Port: 3000]
+        DB[PostgreSQL 17<br/>Port: 5432]
+        CR[Crawler Python<br/>Workers]
+        PG[pgAdmin<br/>Port: 5050]
     end
-    
-    subgraph "Data Flow"
-        A --> B
-        B --> A
-        A --> C
-        C --> A
-        A --> D
-        A --> E
-    end
-    
-    classDef db fill:#e1f5fe,stroke:#333,color:#fff
-    classDef crawler fill:#4caf50,stroke:#333,color:#fff
-    classDef web fill:#2196f3,stroke:#333,color:#fff
-    classDef admin fill:#ff9800,stroke:#333,color:#fff
-    classDef monitoring fill:#9c27b0,stroke:#333,color:#fff
-    
-    class A db
-    class B crawler
-    class C web
-    class D admin
-    class E monitoring
+
+    FE --> API
+    API --> DB
+    CR --> DB
+    PG --> DB
 ```
 
-### 📊 **Services Connectivity**
+### Services
 
-| Service | Container | Port | Description |
-|----------|-----------|------|-------------|
-| PostgreSQL | openindex-postgres | 5432 | Base de données principale |
-| Crawler | openindex-crawler | - | Service d'indexation |
-| Web UI | openindex-web | 8502 | Interface utilisateur |
-| pgAdmin | openindex-pgadmin | 5050 | Administration BDD |
-| Grafana | openindex-grafana | 3000 | Monitoring dashboards |
+| Service | Fichier clé | Port | Rôle |
+|---|---|---:|---|
+| Frontend | `frontend/index.html` + `nginx/nginx.conf` | 3000 | UI utilisateur |
+| API | `src/api/main.py` | 8000 | Endpoints REST + WebSocket |
+| Crawler | `src/smb_crawler_postgresql.py` | - | Indexation SMB |
+| PostgreSQL | `database/init.sql` | 5432 | Stockage principal |
+| pgAdmin (optionnel) | `docker-compose.modern.yml` | 5050 | Administration BDD |
 
-## 🐳 **Services**
+## 🚀 Déploiement recommandé
 
-### 📊 **PostgreSQL (Base de données)**
-- **Image** : `postgres:17-alpine`
-- **Rôle** : Base de données principale
-- **Volumes** : Données persistantes + scripts d'init
-- **Healthcheck** : Vérification de disponibilité
-
-### 🔍 **Crawler (Microservice Python)**
-- **Dockerfile** : `Dockerfile.crawler`
-- **Rôle** : Indexation SMB avec PostgreSQL
-- **Workers** : Multi-threading avec queues séparées
-- **Configuration** : Variables d'environnement complètes
-
-### 🌐 **Web UI (Microservice Web)**
-- **Dockerfile** : `Dockerfile.web`
-- **Rôle** : Interface Streamlit autonome
-- **Accès** : Interface web moderne
-- **Monitoring** : Healthcheck intégré
-
-### 🔧 **Services Optionnels**
-- **pgAdmin** : Administration base de données
-- **Grafana** : Monitoring et dashboards
-
-## 🚀 **Déploiement**
-
-### Installation rapide
+### Démarrage complet
 ```bash
-# 1. Cloner le projet
-git clone <repository>
-cd OpenIndex
-
-# 2. Déployer la stack complète
-./deploy-stack.sh full
-
-# 3. Accéder aux services
-# Web UI: http://localhost:8502
-# pgAdmin: http://localhost:5050
-# Grafana: http://localhost:3000 (admin/admin123)
+./deploy-modern.sh modern
 ```
 
-### Déploiement modulaire
+### Démarrage par composant
 ```bash
-# Interface web uniquement
-./deploy-stack.sh web
-
-# Crawler uniquement
-./deploy-stack.sh crawler
-
-# Outils d'admin
-./deploy-stack.sh admin
+./deploy-modern.sh api
+./deploy-modern.sh frontend
+./deploy-modern.sh crawler
 ```
 
-## 📁 **Structure des fichiers**
-
-```
-OpenIndex/
-├── Dockerfile.crawler          # Service Crawler Python
-├── Dockerfile.web              # Service Web UI
-├── docker-compose.stack.yml   # Stack complète
-├── deploy-stack.sh            # Script de déploiement
-├── src/
-│   ├── smb_crawler_postgresql.py  # Crawler amélioré
-│   ├── web_interface_v2.py         # Interface web
-│   ├── postgres_adapter.py          # Adaptateur PostgreSQL
-│   └── ...                       # Autres modules
-├── database/
-│   └── init.sql                 # Schema PostgreSQL
-├── config/
-│   └── admin_credentials.ini     # Configuration
-└── .env                        # Variables d'environnement
-```
-
-## 🔧 **Configuration**
-
-### Variables d'environnement
+### Vérification rapide
 ```bash
-# Base de données
-POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
-POSTGRES_DB=openindex
-POSTGRES_USER=openindex_user
-POSTGRES_PASSWORD=secure_password
-
-# SMB
-SMB_SERVER=172.16.252.34
-SMB_SHARE=Public\\SEPM
-SMB_DOMAIN=SMIDEN
-SMB_USERNAME=adminsmiden
-SMB_PASSWORD=secret_password
-
-# Crawler
-CRAWLER_WORKERS=4
-CRAWLER_DELAY=0.1
-LARGE_FILE_THRESHOLD=104857600
-DEBUG_MODE=false
-
-# Web UI
-STREAMLIT_SERVER_PORT=8502
-STREAMLIT_SERVER_ADDRESS=0.0.0.0
+./deploy-modern.sh status
 ```
 
-## 🎯 **Avantages de l'architecture**
+## 🧹 Nettoyage docs legacy
 
-### ✅ **Scalabilité**
-- Services indépendants
-- Scaling horizontal possible
-- Isolation des ressources
+- Les anciennes références de stack Streamlit doivent rester cantonnées à :
+  - `archives/`
+  - `Archives/`
+- Toute nouvelle documentation technique doit pointer vers :
+  - `docker-compose.modern.yml`
+  - `deploy-modern.sh`
+  - `Dockerfile.api` / `Dockerfile.frontend` / `Dockerfile.crawler`
 
-### 🔄 **Déploiement continu**
-- Mises à jour indépendantes
-- Rollbacks faciles
-- Tests isolés
+## 📌 Règle éditoriale
 
-### 🛡️ **Sécurité**
-- Isolation par service
-- Variables d'environnement
-- Réseau dédié
+Avant toute mise à jour de documentation, vérifier la cohérence de la stack sur ces trois fichiers :
+- `README.md`
+- `README.stack.md`
+- `ROADMAP.md`
 
-### 📊 **Monitoring**
-- Healthchecks individuels
-- Logs centralisés
-- Métriques par service
-
-## 🚀 **Utilisation**
-
-### Développement
-```bash
-# Lancer les services en mode développement
-docker-compose -f docker-compose.stack.yml --build up
-
-# Logs en temps réel
-docker-compose -f docker-compose.stack.yml logs -f
-```
-
-### Production
-```bash
-# Déploiement production
-./deploy-stack.sh full
-
-# Mise à jour d'un service
-docker-compose -f docker-compose.stack.yml up -d --build web
-```
-
-Cette architecture microservices offre une flexibilité maximale pour le développement, le déploiement et la maintenance d'OpenIndex !
+Cela évite la réintroduction de consignes legacy dans le parcours de démarrage.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,8 @@ L'architecture a été migrée vers une stack moderne microservices avec :
   - [ ] Livraison de fin de journée : état d'avancement, risques et décisions documentées
 
 - **Jour 3 (Mercredi 28/02) - 7h** :
+  - [x] Clarification de la stack officielle (README/README.stack/ROADMAP alignés)
+  - [x] Nettoyage documentaire legacy (références Streamlit déplacées en historique)
   - [ ] Configuration CI/CD complète (build + test + deploy)
   - [ ] Déploiement staging automatique
   - [ ] Monitoring Grafana dashboards

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,15 @@ Objectif J2 : verrouiller un plan réaliste et partagé pour les tests de stabil
 - [ ] Valider le monitoring WebSocket en conditions multi-clients
 - [ ] Publier le bilan J2 en fin de journée (résultats, blocages, arbitrages)
 
+## 🗓️ Proposition J3 (clarification stack + nettoyage docs legacy)
+
+Objectif J3 : supprimer toute ambiguïté entre stack actuelle et historique afin d'éviter les erreurs de déploiement.
+
+- [x] Établir une table "stack actuelle vs stack legacy" dans `README.stack.md`
+- [x] Basculer `README.stack.md` en document de référence moderne
+- [x] Expliciter la règle de nettoyage documentaire (legacy cantonné à `archives/` et `Archives/`)
+- [ ] Vérifier que les prochaines docs techniques ne réintroduisent pas `deploy-stack.sh` en parcours par défaut
+
 ### � **Phase 1 : Stabilisation Architecture Moderne (Semaine 26 Février - 5 Mars 2026)**
 
 #### ✅ **Terminées - 26 Février 2026**


### PR DESCRIPTION
### Motivation

- Supprimer l'ambiguïté entre la stack moderne (FastAPI + frontend statique + PostgreSQL) et la documentation historique basée sur Streamlit afin d'éviter des erreurs de déploiement.
- Centraliser la source de vérité pour le démarrage et les commandes d'orchestration afin de réduire la dérive documentaire.

### Description

- Réécriture de `README.stack.md` pour en faire le document de référence de la stack moderne et ajout d'un tableau `stack actuelle vs stack legacy` et de règles de nettoyage documentaire.
- Suppression des instructions Streamlit legacy dans `README.md` et ajout d'une courte section de clarification renvoyant vers `README.stack.md` et les outils modernes (`docker-compose.modern.yml`, `deploy-modern.sh`).
- Mise à jour de `ROADMAP.md` pour marquer les tâches J3 (clarification + nettoyage) comme réalisées.
- Ajout d'une section `Proposition J3` dans `TODO.md` avec checklist traçant les actions de clarification et la règle de confinement des docs legacy dans `archives/`.

### Testing

- Recherches automatisées avec `rg -n "deploy-stack.sh|docker-compose.stack.yml|streamlit run src/web_interface_v2.py|http://localhost:8502" README.md README.stack.md ROADMAP.md TODO.md` ont été exécutées et n'ont identifié plus d'instructions de déploiement legacy dans les fichiers de référence.
- Diff/validation automatique (`git diff` on edited files) et `git status` ont été exécutés pour vérifier les changements appliqués; les sorties ont été examinées et correspondent aux modifications documentaires attendues.
- Aucun code runtime n'a été modifié; cette PR est documentation-only and the automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee8634ffc832ebc7f88900482e060)