### PR TITLE
feat(j3): ajouter Explain/Analyze DB dans l'application

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -118,6 +118,12 @@
                         <i class="fas fa-chart-line mr-3"></i>
                         Monitoring
                     </a>
+                    <a href="#" @click="currentView = 'dbAnalysis'; loadDbExplain()" 
+                       class="flex items-center px-4 py-2 text-sm font-medium rounded-lg hover:bg-gray-100"
+                       :class="currentView === 'dbAnalysis' ? 'bg-blue-50 text-blue-700' : 'text-gray-700'">
+                        <i class="fas fa-database mr-3"></i>
+                        DB Explain
+                    </a>
                 </nav>
             </div>
         </aside>
@@ -336,6 +342,37 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- Vue Analyse DB -->
+                <div x-show="currentView === 'dbAnalysis'" class="fade-in">
+                    <div class="flex justify-between items-center mb-6">
+                        <h2 class="text-2xl font-bold text-gray-900">🧠 Explain / Analyze DB</h2>
+                        <div class="flex items-center space-x-3">
+                            <select x-model="selectedExplainQuery" class="px-3 py-2 border border-gray-300 rounded-lg">
+                                <option value="files_list">Liste des fichiers</option>
+                                <option value="duplicates">Doublons</option>
+                                <option value="stats">Statistiques globales</option>
+                            </select>
+                            <label class="flex items-center text-sm text-gray-700">
+                                <input type="checkbox" x-model="explainAnalyze" class="mr-2">ANALYZE
+                            </label>
+                            <button @click="loadDbExplain()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg">Lancer</button>
+                        </div>
+                    </div>
+                    <div class="card p-6">
+                        <div x-show="loadingDbExplain" class="text-center py-4">
+                            <div class="loading"></div>
+                            <p class="mt-2 text-gray-600">Exécution du plan SQL...</p>
+                        </div>
+                        <template x-if="dbExplainError">
+                            <p class="text-red-600" x-text="dbExplainError"></p>
+                        </template>
+                        <template x-if="!loadingDbExplain && dbExplainPlan.length > 0">
+                            <pre class="bg-gray-900 text-green-200 p-4 rounded-lg overflow-x-auto text-sm" x-text="dbExplainPlan.join('\n')"></pre>
+                        </template>
+                    </div>
+                </div>
+                </div>
             </div>
         </main>
     </div>
@@ -356,6 +393,11 @@
                 ws: null,
                 showNotifications: false,
                 unreadNotifications: 0,
+                selectedExplainQuery: 'files_list',
+                explainAnalyze: true,
+                dbExplainPlan: [],
+                loadingDbExplain: false,
+                dbExplainError: '',
                 
                 init() {
                     this.loadStats();
@@ -367,6 +409,8 @@
                         this.loadFiles();
                     } else if (this.currentView === 'duplicates') {
                         this.loadDuplicates();
+                    } else if (this.currentView === 'dbAnalysis') {
+                        this.loadDbExplain();
                     }
                 },
                 
@@ -410,6 +454,31 @@
                         console.error('Erreur doublons:', error);
                     } finally {
                         this.loading = false;
+                    }
+                },
+                
+
+                async loadDbExplain() {
+                    this.loadingDbExplain = true;
+                    this.dbExplainError = '';
+                    try {
+                        const params = new URLSearchParams({
+                            query_name: this.selectedExplainQuery,
+                            analyze: this.explainAnalyze
+                        });
+                        const response = await fetch(`/api/db-explain?${params}`);
+                        if (!response.ok) {
+                            const details = await response.json();
+                            throw new Error(details.detail || 'Erreur API');
+                        }
+                        const payload = await response.json();
+                        this.dbExplainPlan = payload.plan || [];
+                    } catch (error) {
+                        this.dbExplainError = error.message;
+                        this.dbExplainPlan = [];
+                        console.error('Erreur Explain:', error);
+                    } finally {
+                        this.loadingDbExplain = false;
                     }
                 },
                 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -71,6 +71,12 @@ class WebSocketMessage(BaseModel):
     timestamp: datetime
 
 
+class ExplainPlan(BaseModel):
+    query_name: str
+    analyze: bool
+    plan: List[str]
+
+
 # Connexion à la base de données
 def get_db_adapter():
     """Récupère l'adaptateur PostgreSQL"""
@@ -116,6 +122,35 @@ class ConnectionManager:
 
 
 manager = ConnectionManager()
+
+EXPLAIN_QUERIES = {
+    "files_list": """
+        SELECT id, path, name, size, checksum, last_modified,
+               is_directory, is_duplicate, duplicate_of,
+               created_at, updated_at
+        FROM files
+        ORDER BY is_directory DESC, name ASC
+        LIMIT 100
+    """,
+    "duplicates": """
+        SELECT f1.id, f1.path, f1.name, f1.size, f1.checksum,
+               f2.path as duplicate_of_path
+        FROM files f1
+        JOIN files f2 ON f1.checksum = f2.checksum AND f1.id != f2.id
+        WHERE f1.is_duplicate = TRUE
+        ORDER BY f1.size DESC
+        LIMIT 100
+    """,
+    "stats": """
+        SELECT
+            COUNT(*) as total_files,
+            COUNT(CASE WHEN is_directory = FALSE THEN 1 END) as files_only,
+            COUNT(CASE WHEN is_directory = TRUE THEN 1 END) as directories,
+            COUNT(CASE WHEN is_duplicate = TRUE THEN 1 END) as duplicates,
+            COALESCE(SUM(CASE WHEN is_directory = FALSE THEN size END), 0) as total_size
+        FROM files
+    """,
+}
 
 
 # Routes API
@@ -243,6 +278,29 @@ async def get_duplicates():
     except Exception as e:
         logger.error(f"Erreur get_duplicates: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération des doublons")
+
+
+@app.get("/api/db-explain", response_model=ExplainPlan)
+async def get_db_explain(query_name: str = "files_list", analyze: bool = True):
+    """Récupérer un plan EXPLAIN (ANALYZE) pour les requêtes clés."""
+    if query_name not in EXPLAIN_QUERIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"query_name invalide. Valeurs autorisées: {', '.join(EXPLAIN_QUERIES.keys())}",
+        )
+
+    try:
+        db = get_db_adapter()
+        explain_mode = "EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)" if analyze else "EXPLAIN (FORMAT TEXT)"
+        explain_query = f"{explain_mode} {EXPLAIN_QUERIES[query_name]}"
+
+        results = db.execute_query(explain_query)
+        plan_lines = [row[0] for row in results]
+
+        return ExplainPlan(query_name=query_name, analyze=analyze, plan=plan_lines)
+    except Exception as e:
+        logger.error(f"Erreur get_db_explain: {e}")
+        raise HTTPException(status_code=500, detail="Erreur lors de la récupération du plan EXPLAIN")
 
 
 @app.websocket("/ws")

--- a/tests/test_api_fastapi.py
+++ b/tests/test_api_fastapi.py
@@ -16,6 +16,13 @@ import main as api_main
 class DummyDB:
     def execute_query(self, query, params=None):
         params = params or []
+        if "EXPLAIN" in query:
+            return [
+                ("Seq Scan on files  (cost=0.00..10.00 rows=100 width=64)",),
+                ("Planning Time: 0.123 ms",),
+                ("Execution Time: 0.456 ms",),
+            ]
+
         if "FROM files" in query and "JOIN files f2" in query:
             return [
                 (
@@ -132,3 +139,17 @@ async def test_connection_manager_broadcast_removes_dead_connection():
     await manager.broadcast('{"type":"test"}')
 
     assert manager.active_connections == [ok]
+
+
+def test_get_db_explain_endpoint(client):
+    response = client.get('/api/db-explain', params={'query_name': 'files_list', 'analyze': True})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['query_name'] == 'files_list'
+    assert payload['analyze'] is True
+    assert any('Execution Time' in line for line in payload['plan'])
+
+
+def test_get_db_explain_invalid_query(client):
+    response = client.get('/api/db-explain', params={'query_name': 'not_allowed'})
+    assert response.status_code == 400


### PR DESCRIPTION
### Motivation
- Implémenter la tâche J3 en ajoutant un mécanisme d'analyse de performance SQL (`EXPLAIN` / `EXPLAIN ANALYZE`) pour documenter les plans d'exécution et aider l'optimisation BDD.
- Fournir une UI pour lancer ces vérifications depuis l'application et visualiser le plan sans exécuter de SQL arbitraire.

### Description
- Ajout d'un endpoint `GET /api/db-explain` qui expose une liste blanche de requêtes (`files_list`, `duplicates`, `stats`) et retourne un `ExplainPlan` structuré contenant `query_name`, `analyze` et `plan` (liste de lignes). (fichier modifié: `src/api/main.py`).
- Mise en place de `EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)` si `analyze=true` et `EXPLAIN (FORMAT TEXT)` sinon, tout en évitant l'exécution de SQL arbitraire via le dictionnaire `EXPLAIN_QUERIES`. (fichier modifié: `src/api/main.py`).
- Ajout d'une vue frontend «DB Explain» (menu, sélecteur de requête, option ANALYZE, bouton Lancer, affichage du plan et erreurs) et intégration d'une méthode Alpine.js `loadDbExplain()` pour consommer l'API. (fichier modifié: `frontend/index.html`).
- Extension des tests unitaires dans `tests/test_api_fastapi.py` pour simuler un retour `EXPLAIN` depuis un `DummyDB` et couvrir le cas nominal et le cas d'une `query_name` invalide. (fichier modifié: `tests/test_api_fastapi.py`).

### Testing
- Les nouveaux tests unitaires ont été ajoutés dans `tests/test_api_fastapi.py` mais l'exécution complète via `pytest` a échoué en environnement à cause de l'absence de la dépendance `fastapi` (ModuleNotFoundError). (échec).
- Tentative d'installation des dépendances (`pip install -r requirements.api.txt pytest`) échouée en raison d'un blocage réseau/proxy empêchant l'accès à PyPI, empêchant l'exécution complète des tests d'intégration. (échec).
- Compilation statique des fichiers modifiés avec `python -m compileall` a réussi pour `src/api/main.py`, `frontend/index.html` et `tests/test_api_fastapi.py`. (succès).
- Un serveur statique a été démarré pour vérifier l'intégration frontend et un script Playwright a pris une capture d'écran de la nouvelle vue «DB Explain», montrant l'interface côté client ; les requêtes API depuis le serveur statique retournent 404 car l'API n'est pas servie par `http.server` (vérification UI côté client réussie, vérification API non applicable dans ce contexte). (succès partiel).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeed83c7dc832eb0551561b8ecdcde)