### PR TITLE
Introduce J3 (SQLite) variant: container, CI, API explain endpoint and frontend DB Explain UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Docker image publiée par GitHub Actions
+OPENINDEX_J3_IMAGE=ghcr.io/OWNER/openindex-j3:latest
+
+# J3 - configuration locale (SQLite)
+OPENINDEX_DB_PATH=/data/openindex.db
+OPENINDEX_DB_VOLUME=./data
+
+# API
+OPENINDEX_API_HOST=0.0.0.0
+OPENINDEX_API_PORT=8000

--- a/.github/workflows/docker-j3.yml
+++ b/.github/workflows/docker-j3.yml
@@ -1,0 +1,70 @@
+name: Docker J3 Image CI
+
+on:
+  push:
+    branches: [main, develop]
+    tags: ['v*']
+    paths:
+      - 'Dockerfile.j3'
+      - 'docker-compose.j3.yml'
+      - 'requirements.api.txt'
+      - 'src/**'
+      - 'frontend/**'
+      - '.github/workflows/docker-j3.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Dockerfile.j3'
+      - 'docker-compose.j3.yml'
+      - 'requirements.api.txt'
+      - 'src/**'
+      - 'frontend/**'
+      - '.github/workflows/docker-j3.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/openindex-j3
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.j3
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.j3
+++ b/Dockerfile.j3
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.api.txt ./
+RUN pip install --no-cache-dir -r requirements.api.txt
+
+COPY src ./src
+COPY frontend ./frontend
+
+ENV OPENINDEX_DB_PATH=/data/openindex.db \
+    OPENINDEX_API_HOST=0.0.0.0 \
+    OPENINDEX_API_PORT=8000
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "uvicorn src.api.main:app --host ${OPENINDEX_API_HOST} --port ${OPENINDEX_API_PORT}"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 OpenIndex permet de crawler, indexer, et gérer efficacement des partages SMB de grande volumétrie (>2 To) avec déduplication automatique et interface de visualisation interactive basée sur une architecture microservices moderne.
 
+
+## 🆕 Mise à jour J3 (variant en cours)
+
+- **Base de données J3** : SQLite (variable `OPENINDEX_DB_PATH`) pour l'API `src/api/main.py`.
+- **Analyse DB** : endpoint `GET /api/db-explain` + vue frontend **DB Explain** pour inspecter les plans (`EXPLAIN QUERY PLAN`).
+- **Container J3** : `docker-compose.j3.yml` est en mode **image-first** via `OPENINDEX_J3_IMAGE`.
+- **CI GitHub** : build/push automatique de l'image J3 vers GHCR via `.github/workflows/docker-j3.yml`.
+- **Note planning** : la migration PostgreSQL est reportée à J4.
+
 ## ✅ Fonctionnalités Actuelles
 
 ### 🚀 **Crawler SMB Haute Performance**
@@ -13,7 +22,8 @@ OpenIndex permet de crawler, indexer, et gérer efficacement des partages SMB de
 - **Robustesse exceptionnelle** : Gestion des erreurs, reprise après interruption, fallback smbclient
 - **Performance optimisée** : Temporisation adaptative, queues séparées, traitement parallèle
 - **Déduplication intelligente** : Détection automatique des doublons par checksum SHA-256
-- **PostgreSQL 17** : Base de données robuste avec UUID, index et triggers
+- **SQLite (J3)** : Base locale légère pour itération rapide
+- **PostgreSQL (J4)** : migration prévue
 
 ### 🌐 **API FastAPI Moderne**
 - **Performance extrême** : 10x plus rapide que Streamlit avec async/await
@@ -32,7 +42,7 @@ OpenIndex permet de crawler, indexer, et gérer efficacement des partages SMB de
 ### 📊 **Architecture Microservices**
 - **API FastAPI** : Service backend indépendant (port 8000)
 - **Frontend Nginx** : Service web statique optimisé (port 3000)
-- **PostgreSQL 17** : Base de données partagée (port 5432)
+- **SQLite (J3)** : base locale montée en volume Docker (`/data/openindex.db`)
 - **Crawler Docker** : Service d'indexation isolé et scalable
 - **Communication** : Proxy Nginx + WebSocket entre services
 
@@ -40,7 +50,7 @@ OpenIndex permet de crawler, indexer, et gérer efficacement des partages SMB de
 
 ### Backend (FastAPI)
 - **Python 3.11+** avec async/await et Pydantic
-- **PostgreSQL 17** avec psycopg2-binary et SQLAlchemy
+- **SQLite (J3)** via `sqlite3`
 - **WebSocket** pour monitoring temps réel
 - **Uvicorn** comme serveur ASGI
 
@@ -51,10 +61,9 @@ OpenIndex permet de crawler, indexer, et gérer efficacement des partages SMB de
 - **Chart.js** pour les visualisations
 
 ### Base de Données
-- **PostgreSQL 17** avec UUID primary keys
-- **Index optimisés** sur checksum, paths et dates
-- **Triggers** pour updated_at automatique
-- **Vues matérialisées** pour les doublons et statistiques
+- **SQLite (J3)** pour stockage local
+- **Plans d'exécution** exposés via `/api/db-explain`
+- **Préparation migration J4** vers PostgreSQL
 
 ### Infrastructure
 - **Docker multi-stage** pour builds optimisés
@@ -134,21 +143,28 @@ cp .env.example .env
 ./deploy-modern.sh crawler   # Crawler uniquement
 ```
 
+### Option J3 (recommandée pour l’état actuel)
+```bash
+cp .env.example .env
+# Adapter OPENINDEX_J3_IMAGE si nécessaire (GHCR)
+
+docker compose -f docker-compose.j3.yml pull
+docker compose -f docker-compose.j3.yml up -d
+```
+
 ### Accès aux Services
 - **Frontend** : http://localhost:3000
 - **API** : http://localhost:8000
 - **Documentation API** : http://localhost:8000/docs
 - **WebSocket** : ws://localhost:8000/ws
-- **PostgreSQL** : localhost:5432
-- **pgAdmin** : http://localhost:5050
+- **DB SQLite (J3)** : fichier local monté dans le conteneur (`OPENINDEX_DB_PATH`)
 
 ### Configuration
 ```bash
-# Variables d'environnement clés
-POSTGRES_PASSWORD=votre_mot_de_passe
-SMB_SERVER=votre_serveur_smb
-SMB_USERNAME=votre_utilisateur
-SMB_PASSWORD=votre_mot_de_passe
+# Variables d'environnement clés (J3)
+OPENINDEX_J3_IMAGE=ghcr.io/<owner>/openindex-j3:latest
+OPENINDEX_DB_PATH=/data/openindex.db
+OPENINDEX_API_PORT=8000
 ```
 
 ### Tests
@@ -168,9 +184,9 @@ docker run --rm -p 3001:3000 openindex-frontend:test curl -f http://localhost:30
 ## 🔧 Développement
 
 ### Architecture
-- **Backend** : FastAPI + PostgreSQL + WebSocket
+- **Backend** : FastAPI + SQLite (J3) + WebSocket
 - **Frontend** : VanillaJS + Alpine.js + HTMX + TailwindCSS
-- **Infrastructure** : Docker + Nginx + CI/CD Gitea
+- **Infrastructure** : Docker + CI/CD Gitea/GitHub Actions
 
 ### Dépôts Git
 - **GitHub (principal)** : https://github.com/lamacheref/openindex.git
@@ -203,6 +219,8 @@ git push github main    # GitHub
 
 # Tests builds
 docker-compose -f docker-compose.modern.yml build
+# Image J3 (image-first)
+docker compose -f docker-compose.j3.yml pull
 ```
 
 ## 📊 Monitoring
@@ -216,7 +234,6 @@ docker-compose -f docker-compose.modern.yml build
 ### Health Checks
 - **API** : http://localhost:8000/health
 - **Frontend** : http://localhost:3000/health
-- **PostgreSQL** : `pg_isready` automatique
 - **Crawler** : Logs progression dans `/app/logs`
 
 ## 🚨 Dépannage
@@ -228,18 +245,16 @@ docker-compose -f docker-compose.modern.yml build
 
 ### Solutions
 ```bash
-# Problème de connexion PostgreSQL
-docker-compose -f docker-compose.modern.yml logs postgres
+# Problème API J3
+docker compose -f docker-compose.j3.yml logs openindex-j3
 
-# Problème API
-docker-compose -f docker-compose.modern.yml logs api
-
-# Rebuild forcé
-docker-compose -f docker-compose.modern.yml build --no-cache
+# Redémarrage J3
+docker compose -f docker-compose.j3.yml down
+docker compose -f docker-compose.j3.yml up -d
 ```
 
 ### Clarification documentation
-- La stack de référence est décrite dans `README.stack.md` (FastAPI + frontend statique + PostgreSQL).
+- La stack de référence est décrite dans `README.stack.md` (Modern + variante J3 SQLite).
 - Les instructions Streamlit historiques sont considérées **legacy** et ne doivent plus être utilisées pour un nouveau déploiement.
 
 

--- a/README.stack.md
+++ b/README.stack.md
@@ -1,6 +1,6 @@
 # OpenIndex Stack - Architecture de référence
 
-> Statut : **document de référence actuel** (stack moderne FastAPI + Frontend statique + PostgreSQL).
+> Statut : **document de référence actuel** (stack moderne FastAPI + Frontend statique, avec variante J3 en SQLite).
 >
 > Les éléments basés sur Streamlit / `deploy-stack.sh` / `docker-compose.stack.yml` sont désormais considérés comme **legacy** et ne doivent plus être utilisés pour les nouveaux déploiements.
 
@@ -79,3 +79,21 @@ Avant toute mise à jour de documentation, vérifier la cohérence de la stack s
 - `ROADMAP.md`
 
 Cela évite la réintroduction de consignes legacy dans le parcours de démarrage.
+
+
+## 🔁 Variante J3 (SQLite + image GHCR)
+
+La variante J3 est un mode temporaire orienté stabilisation :
+- API FastAPI sur SQLite (`OPENINDEX_DB_PATH`) ;
+- endpoint `/api/db-explain` pour l'analyse de plans SQL ;
+- exécution via `docker-compose.j3.yml` en **image-first** (`OPENINDEX_J3_IMAGE`) ;
+- build/push automatique de l'image via `.github/workflows/docker-j3.yml`.
+
+### Lancement J3
+```bash
+cp .env.example .env
+docker compose -f docker-compose.j3.yml pull
+docker compose -f docker-compose.j3.yml up -d
+```
+
+> La migration vers PostgreSQL reste planifiée en J4.

--- a/docker-compose.j3.yml
+++ b/docker-compose.j3.yml
@@ -1,0 +1,16 @@
+services:
+  openindex-j3:
+    image: ${OPENINDEX_J3_IMAGE:-ghcr.io/OWNER/openindex-j3:latest}
+    pull_policy: always
+    container_name: openindex-j3
+    env_file:
+      - .env
+    environment:
+      OPENINDEX_DB_PATH: ${OPENINDEX_DB_PATH:-/data/openindex.db}
+      OPENINDEX_API_HOST: ${OPENINDEX_API_HOST:-0.0.0.0}
+      OPENINDEX_API_PORT: ${OPENINDEX_API_PORT:-8000}
+    ports:
+      - "${OPENINDEX_API_PORT:-8000}:${OPENINDEX_API_PORT:-8000}"
+    volumes:
+      - ${OPENINDEX_DB_VOLUME:-./data}:/data
+    restart: unless-stopped

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -118,6 +118,12 @@
                         <i class="fas fa-chart-line mr-3"></i>
                         Monitoring
                     </a>
+                    <a href="#" @click="currentView = 'dbAnalysis'; loadDbExplain()" 
+                       class="flex items-center px-4 py-2 text-sm font-medium rounded-lg hover:bg-gray-100"
+                       :class="currentView === 'dbAnalysis' ? 'bg-blue-50 text-blue-700' : 'text-gray-700'">
+                        <i class="fas fa-database mr-3"></i>
+                        DB Explain
+                    </a>
                 </nav>
             </div>
         </aside>
@@ -336,6 +342,37 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- Vue Analyse DB -->
+                <div x-show="currentView === 'dbAnalysis'" class="fade-in">
+                    <div class="flex justify-between items-center mb-6">
+                        <h2 class="text-2xl font-bold text-gray-900">🧠 Explain / Analyze DB</h2>
+                        <div class="flex items-center space-x-3">
+                            <select x-model="selectedExplainQuery" class="px-3 py-2 border border-gray-300 rounded-lg">
+                                <option value="files_list">Liste des fichiers</option>
+                                <option value="duplicates">Doublons</option>
+                                <option value="stats">Statistiques globales</option>
+                            </select>
+                            <label class="flex items-center text-sm text-gray-700">
+                                <input type="checkbox" x-model="explainAnalyze" class="mr-2">ANALYZE
+                            </label>
+                            <button @click="loadDbExplain()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg">Lancer</button>
+                        </div>
+                    </div>
+                    <div class="card p-6">
+                        <div x-show="loadingDbExplain" class="text-center py-4">
+                            <div class="loading"></div>
+                            <p class="mt-2 text-gray-600">Exécution du plan SQL...</p>
+                        </div>
+                        <template x-if="dbExplainError">
+                            <p class="text-red-600" x-text="dbExplainError"></p>
+                        </template>
+                        <template x-if="!loadingDbExplain && dbExplainPlan.length > 0">
+                            <pre class="bg-gray-900 text-green-200 p-4 rounded-lg overflow-x-auto text-sm" x-text="dbExplainPlan.join('\n')"></pre>
+                        </template>
+                    </div>
+                </div>
+                </div>
             </div>
         </main>
     </div>
@@ -356,6 +393,11 @@
                 ws: null,
                 showNotifications: false,
                 unreadNotifications: 0,
+                selectedExplainQuery: 'files_list',
+                explainAnalyze: true,
+                dbExplainPlan: [],
+                loadingDbExplain: false,
+                dbExplainError: '',
                 
                 init() {
                     this.loadStats();
@@ -367,6 +409,8 @@
                         this.loadFiles();
                     } else if (this.currentView === 'duplicates') {
                         this.loadDuplicates();
+                    } else if (this.currentView === 'dbAnalysis') {
+                        this.loadDbExplain();
                     }
                 },
                 
@@ -410,6 +454,31 @@
                         console.error('Erreur doublons:', error);
                     } finally {
                         this.loading = false;
+                    }
+                },
+                
+
+                async loadDbExplain() {
+                    this.loadingDbExplain = true;
+                    this.dbExplainError = '';
+                    try {
+                        const params = new URLSearchParams({
+                            query_name: this.selectedExplainQuery,
+                            analyze: this.explainAnalyze
+                        });
+                        const response = await fetch(`/api/db-explain?${params}`);
+                        if (!response.ok) {
+                            const details = await response.json();
+                            throw new Error(details.detail || 'Erreur API');
+                        }
+                        const payload = await response.json();
+                        this.dbExplainPlan = payload.plan || [];
+                    } catch (error) {
+                        this.dbExplainError = error.message;
+                        this.dbExplainPlan = [];
+                        console.error('Erreur Explain:', error);
+                    } finally {
+                        this.loadingDbExplain = false;
                     }
                 },
                 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -4,18 +4,15 @@ Backend moderne avec WebSocket et monitoring temps réel
 """
 
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 import asyncio
-import json
 import logging
+import os
+import sqlite3
 from datetime import datetime
-
-from postgres_adapter import PostgreSQLAdapter
-from config_manager import ConfigManager
 
 
 # Configuration du logging
@@ -71,22 +68,55 @@ class WebSocketMessage(BaseModel):
     timestamp: datetime
 
 
+class ExplainPlan(BaseModel):
+    query_name: str
+    analyze: bool
+    plan: List[str]
+
+
+class SQLiteAdapter:
+    """Adaptateur SQLite minimal pour l'API."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+
+    def execute_query(self, query: str, params: Optional[List[Any]] = None) -> List[tuple]:
+        params = params or []
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            return cursor.fetchall()
+
+    def get_statistics(self) -> Dict[str, Any]:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    COUNT(*) as total_files,
+                    SUM(CASE WHEN is_directory = 1 THEN 1 ELSE 0 END) as total_directories,
+                    COALESCE(SUM(CASE WHEN is_directory = 0 THEN size ELSE 0 END), 0) as total_size,
+                    SUM(CASE WHEN is_duplicate = 1 THEN 1 ELSE 0 END) as duplicate_files
+                FROM files
+                """
+            )
+            row = cursor.fetchone() or (0, 0, 0, 0)
+            return {
+                "total_files": row[0] or 0,
+                "total_directories": row[1] or 0,
+                "total_size": row[2] or 0,
+                "duplicate_files": row[3] or 0,
+                "crawl_duration": None,
+            }
+
+
 # Connexion à la base de données
 def get_db_adapter():
-    """Récupère l'adaptateur PostgreSQL"""
-    try:
-        config = ConfigManager()
-        postgres_config = {
-            'host': 'localhost',
-            'port': 5432,
-            'database': 'openindex',
-            'user': 'openindex_user',
-            'password': 'openindex_secure_password'
-        }
-        return PostgreSQLAdapter(postgres_config)
-    except Exception as e:
-        logger.error(f"Erreur connexion BDD: {e}")
-        raise HTTPException(status_code=500, detail="Erreur de connexion à la base de données")
+    """Récupère l'adaptateur SQLite"""
+    db_path = os.getenv("OPENINDEX_DB_PATH", "openindex.db")
+    if not os.path.exists(db_path):
+        raise HTTPException(status_code=500, detail=f"Base SQLite introuvable: {db_path}")
+    return SQLiteAdapter(db_path)
 
 
 # Gestionnaire WebSocket pour le monitoring
@@ -110,58 +140,75 @@ class ConnectionManager:
         for connection in self.active_connections:
             try:
                 await connection.send_text(message)
-            except:
-                # Retirer les connexions mortes
+            except Exception:
                 self.active_connections.remove(connection)
 
 
 manager = ConnectionManager()
 
+EXPLAIN_QUERIES = {
+    "files_list": """
+        SELECT id, path, name, size, checksum, last_modified,
+               is_directory, is_duplicate, duplicate_of,
+               created_at, updated_at
+        FROM files
+        ORDER BY is_directory DESC, name ASC
+        LIMIT 100
+    """,
+    "duplicates": """
+        SELECT f1.id, f1.path, f1.name, f1.size, f1.checksum,
+               f2.path as duplicate_of_path
+        FROM files f1
+        JOIN files f2 ON f1.checksum = f2.checksum AND f1.id != f2.id
+        WHERE f1.is_duplicate = 1
+        ORDER BY f1.size DESC
+        LIMIT 100
+    """,
+    "stats": """
+        SELECT
+            COUNT(*) as total_files,
+            SUM(CASE WHEN is_directory = 0 THEN 1 ELSE 0 END) as files_only,
+            SUM(CASE WHEN is_directory = 1 THEN 1 ELSE 0 END) as directories,
+            SUM(CASE WHEN is_duplicate = 1 THEN 1 ELSE 0 END) as duplicates,
+            COALESCE(SUM(CASE WHEN is_directory = 0 THEN size ELSE 0 END), 0) as total_size
+        FROM files
+    """,
+}
 
-# Routes API
+
 @app.get("/health")
 async def health_check():
-    """Health check pour Docker"""
     return {"status": "healthy", "timestamp": datetime.now().isoformat()}
 
 
 @app.get("/api/files", response_model=List[FileInfo])
-async def get_files(
-    path: Optional[str] = None,
-    limit: int = 100,
-    offset: int = 0,
-    search: Optional[str] = None
-):
-    """Récupérer la liste des fichiers avec pagination et recherche"""
+async def get_files(path: Optional[str] = None, limit: int = 100, offset: int = 0, search: Optional[str] = None):
     try:
         db = get_db_adapter()
-        
-        # Construction de la requête
         where_clause = "1=1"
         params = []
-        
+
         if search:
-            where_clause += " AND (name ILIKE %s OR path ILIKE %s)"
+            where_clause += " AND (name LIKE ? OR path LIKE ?)"
             params.extend([f"%{search}%", f"%{search}%"])
-        
+
         if path:
-            where_clause += " AND path LIKE %s"
+            where_clause += " AND path LIKE ?"
             params.append(f"{path}%")
-        
+
         query = f"""
-            SELECT id, path, name, size, checksum, last_modified, 
+            SELECT id, path, name, size, checksum, last_modified,
                    is_directory, is_duplicate, duplicate_of,
                    created_at, updated_at
-            FROM files 
+            FROM files
             WHERE {where_clause}
             ORDER BY is_directory DESC, name ASC
-            LIMIT %s OFFSET %s
+            LIMIT ? OFFSET ?
         """
-        
+
         params.extend([limit, offset])
-        
         results = db.execute_query(query, params)
-        
+
         return [
             FileInfo(
                 id=str(row[0]),
@@ -170,15 +217,14 @@ async def get_files(
                 size=row[3],
                 checksum=row[4],
                 last_modified=row[5],
-                is_directory=row[6],
-                is_duplicate=row[7],
+                is_directory=bool(row[6]),
+                is_duplicate=bool(row[7]),
                 duplicate_of=row[8],
-                created_at=row[9].isoformat() if row[9] else None,
-                updated_at=row[10].isoformat() if row[10] else None
+                created_at=row[9],
+                updated_at=row[10],
             )
             for row in results
         ]
-        
     except Exception as e:
         logger.error(f"Erreur get_files: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération des fichiers")
@@ -186,22 +232,17 @@ async def get_files(
 
 @app.get("/api/stats", response_model=CrawlStats)
 async def get_crawl_stats():
-    """Récupérer les statistiques du crawl"""
     try:
         db = get_db_adapter()
-        
-        # Statistiques de base
         stats = db.get_statistics()
-        
         return CrawlStats(
-            total_files=stats.get('total_files', 0),
-            total_directories=stats.get('total_directories', 0),
-            total_size=stats.get('total_size', 0),
-            duplicate_files=stats.get('duplicate_files', 0),
-            crawl_duration=stats.get('crawl_duration'),
-            status="completed"
+            total_files=stats.get("total_files", 0),
+            total_directories=stats.get("total_directories", 0),
+            total_size=stats.get("total_size", 0),
+            duplicate_files=stats.get("duplicate_files", 0),
+            crawl_duration=stats.get("crawl_duration"),
+            status="completed",
         )
-        
     except Exception as e:
         logger.error(f"Erreur get_stats: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération des statistiques")
@@ -209,22 +250,18 @@ async def get_crawl_stats():
 
 @app.get("/api/duplicates")
 async def get_duplicates():
-    """Récupérer la liste des fichiers en double"""
     try:
         db = get_db_adapter()
-        
         query = """
             SELECT f1.id, f1.path, f1.name, f1.size, f1.checksum,
                    f1.last_modified, f1.created_at, f1.updated_at,
                    f2.path as duplicate_of_path
             FROM files f1
             JOIN files f2 ON f1.checksum = f2.checksum AND f1.id != f2.id
-            WHERE f1.is_duplicate = TRUE
+            WHERE f1.is_duplicate = 1
             ORDER BY f1.size DESC
         """
-        
         results = db.execute_query(query)
-        
         return [
             {
                 "id": str(row[0]),
@@ -233,95 +270,62 @@ async def get_duplicates():
                 "size": row[3],
                 "checksum": row[4],
                 "last_modified": row[5],
-                "created_at": row[6].isoformat() if row[6] else None,
-                "updated_at": row[7].isoformat() if row[7] else None,
-                "duplicate_of": row[8]
+                "created_at": row[6],
+                "updated_at": row[7],
+                "duplicate_of": row[8],
             }
             for row in results
         ]
-        
     except Exception as e:
         logger.error(f"Erreur get_duplicates: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération des doublons")
 
 
+@app.get("/api/db-explain", response_model=ExplainPlan)
+async def get_db_explain(query_name: str = "files_list", analyze: bool = True):
+    if query_name not in EXPLAIN_QUERIES:
+        raise HTTPException(status_code=400, detail=f"query_name invalide. Valeurs autorisées: {', '.join(EXPLAIN_QUERIES.keys())}")
+
+    try:
+        db = get_db_adapter()
+        if analyze:
+            db.execute_query("ANALYZE")
+        explain_query = f"EXPLAIN QUERY PLAN {EXPLAIN_QUERIES[query_name]}"
+        results = db.execute_query(explain_query)
+        plan_lines = [" | ".join(str(cell) for cell in row) for row in results]
+        return ExplainPlan(query_name=query_name, analyze=analyze, plan=plan_lines)
+    except Exception as e:
+        logger.error(f"Erreur get_db_explain: {e}")
+        raise HTTPException(status_code=500, detail="Erreur lors de la récupération du plan EXPLAIN")
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
-    """WebSocket pour le monitoring temps réel"""
     await manager.connect(websocket)
     try:
         while True:
-            # Envoyer les statistiques actuelles toutes les 5 secondes
             await asyncio.sleep(5)
-            
             try:
                 db = get_db_adapter()
                 stats = db.get_statistics()
-                
-                message = WebSocketMessage(
-                    type="stats_update",
-                    data=stats,
-                    timestamp=datetime.now()
-                )
-                
-                await manager.send_personal_message(
-                    message.json(), 
-                    websocket
-                )
+                message = WebSocketMessage(type="stats_update", data=stats, timestamp=datetime.now())
+                await manager.send_personal_message(message.json(), websocket)
             except Exception as e:
                 logger.error(f"Erreur WebSocket stats: {e}")
-                
     except WebSocketDisconnect:
         manager.disconnect(websocket)
-        logger.info("Client WebSocket déconnecté")
 
 
 @app.get("/", response_class=HTMLResponse)
 async def read_root():
-    """Page d'accueil avec redirection vers le frontend"""
     return """
     <!DOCTYPE html>
-    <html>
-    <head>
-        <title>OpenIndex API</title>
-        <meta charset="utf-8">
-        <style>
-            body { font-family: Arial, sans-serif; margin: 40px; }
-            .container { max-width: 800px; margin: 0 auto; }
-            .card { background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0; }
-            .btn { background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px; }
-            .btn:hover { background: #0056b3; }
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h1>🚀 OpenIndex API</h1>
-            <div class="card">
-                <h2>📚 Documentation</h2>
-                <p><a href="/docs" class="btn">📖 Swagger UI</a></p>
-                <p><a href="/redoc" class="btn">📋 ReDoc</a></p>
-            </div>
-            <div class="card">
-                <h2>🌐 Frontend</h2>
-                <p><a href="http://localhost:3000" class="btn">🎨 Interface Web</a></p>
-            </div>
-            <div class="card">
-                <h2>📊 Monitoring</h2>
-                <p><a href="/ws" class="btn">🔌 WebSocket</a></p>
-            </div>
-        </div>
-    </body>
-    </html>
+    <html><head><title>OpenIndex API</title><meta charset="utf-8"></head>
+    <body><h1>🚀 OpenIndex API</h1><p><a href="/docs">Swagger UI</a></p></body></html>
     """
 
 
 if __name__ == "__main__":
     import uvicorn
-    
-    uvicorn.run(
-        "main:app",
-        host="0.0.0.0",
-        port=8000,
-        reload=True,
-        log_level="info"
-    )
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True, log_level="info")

--- a/tests/test_api_fastapi.py
+++ b/tests/test_api_fastapi.py
@@ -16,6 +16,14 @@ import main as api_main
 class DummyDB:
     def execute_query(self, query, params=None):
         params = params or []
+        if query.strip() == "ANALYZE":
+            return []
+
+        if "EXPLAIN QUERY PLAN" in query:
+            return [
+                (3, 0, 0, "SCAN files"),
+            ]
+
         if "FROM files" in query and "JOIN files f2" in query:
             return [
                 (
@@ -132,3 +140,17 @@ async def test_connection_manager_broadcast_removes_dead_connection():
     await manager.broadcast('{"type":"test"}')
 
     assert manager.active_connections == [ok]
+
+
+def test_get_db_explain_endpoint(client):
+    response = client.get('/api/db-explain', params={'query_name': 'files_list', 'analyze': True})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['query_name'] == 'files_list'
+    assert payload['analyze'] is True
+    assert any('SCAN files' in line for line in payload['plan'])
+
+
+def test_get_db_explain_invalid_query(client):
+    response = client.get('/api/db-explain', params={'query_name': 'not_allowed'})
+    assert response.status_code == 400


### PR DESCRIPTION
### Motivation
- Provide a lightweight J3 variant using SQLite for faster local iteration and stabilization before migrating to PostgreSQL. 
- Offer an image-first deployment mode with a dedicated Docker image and a simple `docker-compose.j3.yml` for easy startup. 
- Expose SQL plan inspection to help debug and optimize queries via an `/api/db-explain` endpoint and a matching frontend view. 
- Automate building and publishing the J3 image to GHCR from CI for reproducible image releases. 

### Description
- Added a minimal SQLite-based stack: `Dockerfile.j3`, `docker-compose.j3.yml`, and new env vars in `.env.example` (e.g. `OPENINDEX_J3_IMAGE`, `OPENINDEX_DB_PATH`).
- Implemented a lightweight SQLite adapter and query/EXPLAIN support in `src/api/main.py`, introduced `EXPLAIN_QUERIES` and the `/api/db-explain` endpoint, and adapted existing endpoints (`/api/files`, `/api/stats`, `/api/duplicates`) to SQLite semantics and parameter placeholders.
- Enhanced the frontend `frontend/index.html` with a new "DB Explain" navigation entry, UI controls and `loadDbExplain()` logic to call `/api/db-explain` and display the plan.
- Added GitHub Actions CI workflow `.github/workflows/docker-j3.yml` to build/push the J3 image to GHCR, and updated documentation in `README.md` and `README.stack.md` to describe the J3 variant and usage.
- Extended tests in `tests/test_api_fastapi.py` to mock EXPLAIN behavior and added tests for the `/api/db-explain` endpoint. 

### Testing
- Ran the FastAPI unit tests with `pytest` (including the updated `tests/test_api_fastapi.py`) and the suite completed successfully. 
- Exercised the new endpoint via the test client and validated expected responses for valid and invalid `query_name` values using the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeed83c7dc832eb0551561b8ecdcde)