### PR TITLE
feat: activer les espaces depuis la base de données

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,6 +93,21 @@
         <aside class="sidebar w-64 bg-white shadow-lg fixed left-0 top-16 h-full z-40 border-r border-gray-200"
                :class="sidebarOpen ? '' : 'sidebar-closed'">
             <div class="p-6">
+                <div class="mb-6">
+                    <p class="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">Espaces</p>
+                    <div class="space-y-1">
+                        <template x-for="space in spaces" :key="space.path_prefix">
+                            <button @click="selectSpace(space.path_prefix)"
+                                    class="w-full text-left flex items-center justify-between px-3 py-2 text-sm rounded-lg hover:bg-gray-100"
+                                    :class="activeSpace === space.path_prefix ? 'bg-blue-50 text-blue-700' : 'text-gray-700'">
+                                <span class="truncate" x-text="space.name"></span>
+                                <span class="text-xs text-gray-500" x-text="space.file_count"></span>
+                            </button>
+                        </template>
+                        <p x-show="spaces.length === 0" class="text-xs text-gray-500 px-3 py-2">Aucun espace détecté</p>
+                    </div>
+                </div>
+
                 <nav class="space-y-2">
                     <a href="#" @click="currentView = 'dashboard'" 
                        class="flex items-center px-4 py-2 text-sm font-medium rounded-lg hover:bg-gray-100"
@@ -398,8 +413,11 @@
                 dbExplainPlan: [],
                 loadingDbExplain: false,
                 dbExplainError: '',
+                spaces: [],
+                activeSpace: '',
                 
-                init() {
+                async init() {
+                    await this.loadSpaces();
                     this.loadStats();
                     this.initWebSocket();
                     this.initCharts();
@@ -420,7 +438,11 @@
                 
                 async loadStats() {
                     try {
-                        const response = await fetch('/api/stats');
+                        const params = new URLSearchParams();
+                        if (this.activeSpace) {
+                            params.append('space', this.activeSpace);
+                        }
+                        const response = await fetch(`/api/stats?${params}`);
                         this.stats = await response.json();
                     } catch (error) {
                         console.error('Erreur stats:', error);
@@ -435,6 +457,9 @@
                             offset: 0,
                             search: this.searchQuery
                         });
+                        if (this.activeSpace) {
+                            params.append('space', this.activeSpace);
+                        }
                         
                         const response = await fetch(`/api/files?${params}`);
                         this.files = await response.json();
@@ -448,12 +473,38 @@
                 async loadDuplicates() {
                     this.loading = true;
                     try {
-                        const response = await fetch('/api/duplicates');
+                        const params = new URLSearchParams();
+                        if (this.activeSpace) {
+                            params.append('space', this.activeSpace);
+                        }
+                        const response = await fetch(`/api/duplicates?${params}`);
                         this.duplicates = await response.json();
                     } catch (error) {
                         console.error('Erreur doublons:', error);
                     } finally {
                         this.loading = false;
+                    }
+                },
+                
+                async loadSpaces() {
+                    try {
+                        const response = await fetch('/api/spaces');
+                        this.spaces = await response.json();
+                        if (!this.activeSpace && this.spaces.length > 0) {
+                            this.activeSpace = this.spaces[0].path_prefix;
+                        }
+                    } catch (error) {
+                        console.error('Erreur espaces:', error);
+                    }
+                },
+
+                async selectSpace(spacePrefix) {
+                    this.activeSpace = spacePrefix;
+                    await this.loadStats();
+                    if (this.currentView === 'files') {
+                        await this.loadFiles();
+                    } else if (this.currentView === 'duplicates') {
+                        await this.loadDuplicates();
                     }
                 },
                 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -62,6 +62,12 @@ class CrawlStats(BaseModel):
     status: str
 
 
+class SpaceInfo(BaseModel):
+    name: str
+    path_prefix: str
+    file_count: int
+
+
 class WebSocketMessage(BaseModel):
     type: str
     data: Dict[str, Any]
@@ -87,19 +93,23 @@ class SQLiteAdapter:
             cursor.execute(query, params)
             return cursor.fetchall()
 
-    def get_statistics(self) -> Dict[str, Any]:
+    def get_statistics(self, space: Optional[str] = None) -> Dict[str, Any]:
+        query = """
+            SELECT
+                COUNT(*) as total_files,
+                SUM(CASE WHEN is_directory = 1 THEN 1 ELSE 0 END) as total_directories,
+                COALESCE(SUM(CASE WHEN is_directory = 0 THEN size ELSE 0 END), 0) as total_size,
+                SUM(CASE WHEN is_duplicate = 1 THEN 1 ELSE 0 END) as duplicate_files
+            FROM files
+        """
+        params: List[Any] = []
+        if space:
+            query += " WHERE path LIKE ?"
+            params.append(f"{space}%")
+
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT
-                    COUNT(*) as total_files,
-                    SUM(CASE WHEN is_directory = 1 THEN 1 ELSE 0 END) as total_directories,
-                    COALESCE(SUM(CASE WHEN is_directory = 0 THEN size ELSE 0 END), 0) as total_size,
-                    SUM(CASE WHEN is_duplicate = 1 THEN 1 ELSE 0 END) as duplicate_files
-                FROM files
-                """
-            )
+            cursor.execute(query, params)
             row = cursor.fetchone() or (0, 0, 0, 0)
             return {
                 "total_files": row[0] or 0,
@@ -108,6 +118,53 @@ class SQLiteAdapter:
                 "duplicate_files": row[3] or 0,
                 "crawl_duration": None,
             }
+
+    def get_spaces(self) -> List[Dict[str, Any]]:
+        paths = self.execute_query("SELECT path FROM files WHERE path IS NOT NULL")
+        spaces: Dict[str, Dict[str, Any]] = {}
+
+        for row in paths:
+            path = row[0]
+            if not path:
+                continue
+
+            prefix = self._extract_space_prefix(path)
+            if not prefix:
+                continue
+
+            if prefix not in spaces:
+                spaces[prefix] = {
+                    "name": prefix.replace("/", "").replace("\\", "") or prefix,
+                    "path_prefix": prefix,
+                    "file_count": 0,
+                }
+            spaces[prefix]["file_count"] += 1
+
+        return sorted(spaces.values(), key=lambda item: item["name"].lower())
+
+    @staticmethod
+    def _extract_space_prefix(path: str) -> Optional[str]:
+        normalized = path.strip()
+        if not normalized:
+            return None
+
+        if normalized.startswith("\\"):
+            parts = [part for part in normalized.split("\\") if part]
+            if len(parts) >= 2:
+                return f"\\{parts[0]}\\{parts[1]}"
+            return None
+
+        if normalized.startswith("/"):
+            parts = [part for part in normalized.split("/") if part]
+            if parts:
+                return f"/{parts[0]}"
+            return "/"
+
+        parts = [part for part in normalized.replace("\\", "/").split("/") if part]
+        if parts:
+            return parts[0]
+
+        return None
 
 
 # Connexion à la base de données
@@ -182,7 +239,7 @@ async def health_check():
 
 
 @app.get("/api/files", response_model=List[FileInfo])
-async def get_files(path: Optional[str] = None, limit: int = 100, offset: int = 0, search: Optional[str] = None):
+async def get_files(path: Optional[str] = None, limit: int = 100, offset: int = 0, search: Optional[str] = None, space: Optional[str] = None):
     try:
         db = get_db_adapter()
         where_clause = "1=1"
@@ -195,6 +252,10 @@ async def get_files(path: Optional[str] = None, limit: int = 100, offset: int = 
         if path:
             where_clause += " AND path LIKE ?"
             params.append(f"{path}%")
+
+        if space:
+            where_clause += " AND path LIKE ?"
+            params.append(f"{space}%")
 
         query = f"""
             SELECT id, path, name, size, checksum, last_modified,
@@ -231,10 +292,10 @@ async def get_files(path: Optional[str] = None, limit: int = 100, offset: int = 
 
 
 @app.get("/api/stats", response_model=CrawlStats)
-async def get_crawl_stats():
+async def get_crawl_stats(space: Optional[str] = None):
     try:
         db = get_db_adapter()
-        stats = db.get_statistics()
+        stats = db.get_statistics(space=space)
         return CrawlStats(
             total_files=stats.get("total_files", 0),
             total_directories=stats.get("total_directories", 0),
@@ -249,7 +310,7 @@ async def get_crawl_stats():
 
 
 @app.get("/api/duplicates")
-async def get_duplicates():
+async def get_duplicates(space: Optional[str] = None):
     try:
         db = get_db_adapter()
         query = """
@@ -259,9 +320,13 @@ async def get_duplicates():
             FROM files f1
             JOIN files f2 ON f1.checksum = f2.checksum AND f1.id != f2.id
             WHERE f1.is_duplicate = 1
-            ORDER BY f1.size DESC
         """
-        results = db.execute_query(query)
+        params: List[Any] = []
+        if space:
+            query += " AND f1.path LIKE ?"
+            params.append(f"{space}%")
+        query += " ORDER BY f1.size DESC"
+        results = db.execute_query(query, params)
         return [
             {
                 "id": str(row[0]),
@@ -279,6 +344,16 @@ async def get_duplicates():
     except Exception as e:
         logger.error(f"Erreur get_duplicates: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération des doublons")
+
+
+@app.get("/api/spaces", response_model=List[SpaceInfo])
+async def get_spaces():
+    try:
+        db = get_db_adapter()
+        return [SpaceInfo(**space) for space in db.get_spaces()]
+    except Exception as e:
+        logger.error(f"Erreur get_spaces: {e}")
+        raise HTTPException(status_code=500, detail="Erreur lors de la récupération des espaces")
 
 
 @app.get("/api/db-explain", response_model=ExplainPlan)

--- a/tests/test_api_fastapi.py
+++ b/tests/test_api_fastapi.py
@@ -39,6 +39,12 @@ class DummyDB:
                 )
             ]
 
+        if "SELECT path FROM files WHERE path IS NOT NULL" in query:
+            return [
+                ("/share/docs",),
+                ("/share/original/a.txt",),
+            ]
+
         # /api/files
         return [
             (
@@ -69,7 +75,7 @@ class DummyDB:
             ),
         ]
 
-    def get_statistics(self):
+    def get_statistics(self, space=None):
         return {
             "total_files": 2,
             "total_directories": 1,
@@ -110,6 +116,14 @@ def test_get_duplicates_endpoint(client):
     assert response.status_code == 200
     payload = response.json()
     assert payload[0]["duplicate_of"] == "/share/original/a.txt"
+
+
+def test_get_spaces_endpoint(client):
+    response = client.get("/api/spaces")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["path_prefix"] == "/share"
+    assert payload[0]["file_count"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Permettre à l'UI de rendre chaque « espace » sélectionnable et actif en se basant sur les chemins réellement indexés en base de données afin de filtrer les vues (fichiers, stats, doublons).

### Description
- Ajout du modèle Pydantic `SpaceInfo` et de la méthode `SQLiteAdapter.get_spaces()` qui extrait les préfixes d'espace depuis les chemins stockés en base.
- Ajout de l'endpoint `GET /api/spaces` et prise en charge du paramètre optionnel `space` sur `GET /api/files`, `GET /api/stats` et `GET /api/duplicates` pour filtrer par préfixe.
- Mise à jour du frontend statique `frontend/index.html` (Alpine.js) pour charger dynamiquement la liste des espaces, afficher la section « Espaces » dans la sidebar, gérer `spaces`/`activeSpace`, et recharger `stats`, `files` et `duplicates` lors de la sélection.
- Adaptation des tests `tests/test_api_fastapi.py` pour mocker la nouvelle requête de chemins, accepter la nouvelle signature `get_statistics(space=...)` et ajouter `test_get_spaces_endpoint`.

### Testing
- `python -m py_compile src/api/main.py tests/test_api_fastapi.py` a été exécuté avec succès (fichier Python compilable).
- `pytest -q tests/test_api_fastapi.py` a été lancé mais a échoué dans cet environnement CI local à cause de l'absence de la dépendance `fastapi` (ModuleNotFoundError), donc les tests d'intégration n'ont pas pu s'exécuter ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0711f084832ebd0f83902d78e91a)