### PR TITLE
J1: runbook hebdo, tests smoke API critiques et procédure de reprise SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog OpenIndex
 
+## 2026-03-10 — Exécution objectifs critiques TODO J1
+
+- Ajout d'un runbook hebdomadaire court avec checklist opératoire.
+- Formalisation d'un lot de tests API critiques reproductibles (`tests/test_api_smoke_critical.py`).
+- Documentation de la reprise sur incident SQLite (absence/corruption) avec procédure et commandes.
+
 ## 2026-03-10 — Lancement J1
 
 - Lancement officiel de la phase **J1** (kickoff opérationnel).

--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ docker compose -f docker-compose.j3.yml up -d
 - Suivi d’exécution : `TODO.md`
 - Historique : `CHANGELOG.md`
 - Journal détaillé : `docs/`
+- Runbook hebdo J1 + reprise SQLite : `docs/RUNBOOK_HEBDO.md`
 - Plan d'accélération 2 semaines : `docs/OPTION_COMMANDO.md`

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,9 @@
 
 ## Priorité critique (J1)
 
-- [ ] Établir une checklist de démarrage hebdo (runbook court).
-- [ ] Valider un jeu de tests reproductible API (`/health`, `/api/stats`, `/api/files`, `/api/db-explain`).
-- [ ] Décrire la procédure de reprise sur incident SQLite (absence/corruption).
+- [x] Établir une checklist de démarrage hebdo (runbook court).
+- [x] Valider un jeu de tests reproductible API (`/health`, `/api/stats`, `/api/files`, `/api/db-explain`).
+- [x] Décrire la procédure de reprise sur incident SQLite (absence/corruption).
 
 ## Priorité haute
 

--- a/docs/RUNBOOK_HEBDO.md
+++ b/docs/RUNBOOK_HEBDO.md
@@ -1,0 +1,91 @@
+# Runbook hebdo J1 (court)
+
+## Objectif
+
+Standardiser un démarrage hebdomadaire en moins de 20 minutes avec un lot de contrôles reproductibles.
+
+## Checklist de démarrage (ordre recommandé)
+
+- [ ] Vérifier la version et le contexte de branche.
+- [ ] Vérifier que les services montent (`api`, `web`, `db` SQLite via volume).
+- [ ] Exécuter le jeu de tests API critique J1.
+- [ ] Vérifier rapidement la santé applicative et les stats.
+- [ ] Contrôler la présence du fichier SQLite actif.
+- [ ] Archiver les constats dans `docs/` (date + anomalies).
+
+## Commandes opératoires
+
+```bash
+# 1) Contexte git
+python3 -V
+git rev-parse --abbrev-ref HEAD
+git status --short
+
+# 2) Démarrage stack (variante active J3)
+docker compose -f docker-compose.j3.yml up -d
+
+# 3) Jeu de tests API critique reproductible
+pytest -q tests/test_api_smoke_critical.py
+
+# 4) Smoke runtime (optionnel mais recommandé)
+curl -s http://localhost:8000/health
+curl -s http://localhost:8000/api/stats
+curl -s "http://localhost:8000/api/files?limit=5&offset=0"
+curl -s "http://localhost:8000/api/db-explain?query_name=files_list"
+```
+
+## Procédure de reprise sur incident SQLite (absence/corruption)
+
+### Symptômes typiques
+
+- API indisponible au démarrage avec erreurs SQLite (`database disk image is malformed`, `unable to open database file`).
+- Endpoint `/health` indisponible ou en erreur.
+- Requêtes `/api/stats` ou `/api/files` en 5xx.
+
+### Procédure pas-à-pas
+
+1. **Stopper les écritures applicatives**
+   - Arrêter temporairement l'API pour figer l'état.
+2. **Sauvegarder l'état courant avant action**
+   - Copier le fichier DB actuel vers un répertoire de quarantaine daté.
+3. **Tenter une vérification d'intégrité**
+   - `sqlite3 <db_path> "PRAGMA integrity_check;"`
+4. **Si corruption confirmée, tenter une reconstruction**
+   - `sqlite3 <db_path> ".recover" | sqlite3 <db_recovered_path>`
+5. **Basculer l'API sur la base reconstruite**
+   - Mettre à jour `OPENINDEX_DB_PATH` puis redémarrer l'API.
+6. **Valider le service**
+   - Vérifier `/health`, `/api/stats`, `/api/files`, `/api/db-explain`.
+7. **Si reconstruction impossible**
+   - Recréer une base saine via `database/init.sql` puis relancer un crawl.
+8. **Documenter l'incident**
+   - Date, impact, cause probable, action corrective et action préventive dans `docs/`.
+
+### Commandes utiles (exemple)
+
+```bash
+# Variables d'exemple
+export OPENINDEX_DB_PATH=/data/openindex/index.db
+export DB_BAK_DIR=/data/openindex/backup/$(date +%F_%H%M)
+mkdir -p "$DB_BAK_DIR"
+
+# 1) Backup
+cp "$OPENINDEX_DB_PATH" "$DB_BAK_DIR/index.db.before_recovery"
+
+# 2) Diagnostic
+sqlite3 "$OPENINDEX_DB_PATH" "PRAGMA integrity_check;"
+
+# 3) Reconstruction
+sqlite3 "$OPENINDEX_DB_PATH" ".recover" | sqlite3 "$DB_BAK_DIR/index.recovered.db"
+
+# 4) Validation minimale
+sqlite3 "$DB_BAK_DIR/index.recovered.db" "PRAGMA integrity_check;"
+```
+
+## Critère de validation hebdo
+
+Le démarrage hebdo est validé si :
+
+- Le test `tests/test_api_smoke_critical.py` passe sans modification locale.
+- Les 4 endpoints critiques répondent en 2xx.
+- Aucun incident bloquant SQLite n'est ouvert.

--- a/tests/test_api_smoke_critical.py
+++ b/tests/test_api_smoke_critical.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "api"))
+
+import main as api_main
+
+
+class DummyDB:
+    def execute_query(self, query, params=None):
+        params = params or []
+
+        if query.strip() == "ANALYZE":
+            return []
+
+        if "EXPLAIN QUERY PLAN" in query:
+            return [(3, 0, 0, "SCAN files")]
+
+        return [
+            (
+                "00000000-0000-0000-0000-000000000010",
+                "/share/docs",
+                "docs",
+                None,
+                None,
+                None,
+                True,
+                False,
+                None,
+                None,
+                None,
+            )
+        ]
+
+    def get_statistics(self, space=None):
+        return {
+            "total_files": 1,
+            "total_directories": 1,
+            "total_size": 0,
+            "duplicate_files": 0,
+            "crawl_duration": 0.1,
+        }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(api_main, "get_db_adapter", lambda: DummyDB())
+    return TestClient(api_main.app)
+
+
+def test_critical_health(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+
+
+def test_critical_stats(client):
+    response = client.get("/api/stats")
+    assert response.status_code == 200
+    assert response.json()["total_files"] == 1
+
+
+def test_critical_files(client):
+    response = client.get("/api/files", params={"limit": 10, "offset": 0})
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["path"] == "/share/docs"
+
+
+def test_critical_db_explain(client):
+    response = client.get("/api/db-explain", params={"query_name": "files_list", "analyze": True})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["query_name"] == "files_list"
+    assert payload["analyze"] is True
+    assert any("SCAN files" in line for line in payload["plan"])


### PR DESCRIPTION
### Motivation

- Finaliser les objectifs critiques J1 en standardisant le démarrage hebdo, en fournissant un jeu de tests API reproductible et en documentant la procédure de reprise sur incident SQLite.

### Description

- Ajout du runbook `docs/RUNBOOK_HEBDO.md` contenant checklist, commandes opératoires, procédure de reprise SQLite et critères de validation hebdo.
- Ajout du test smoke `tests/test_api_smoke_critical.py` qui utilise une fixture `DummyDB` et `TestClient` pour vérifier `/health`, `/api/stats`, `/api/files` et `/api/db-explain` de manière déterministe.
- Mise à jour de `TODO.md` pour cocher les objectifs critiques et ajout d’une référence au runbook dans `README.md` ainsi qu’une entrée dédiée dans `CHANGELOG.md`.
- Les changements rendent les vérifications critiques reproductibles localement sans dépendre d’une base réelle en production grâce au `DummyDB` utilisé par le test.

### Testing

- La compilation des modules de test a été vérifiée avec `python3 -m compileall tests/test_api_smoke_critical.py src/api/main.py` et a réussi.
- L’exécution `pytest -q tests/test_api_smoke_critical.py` a échoué dans cet environnement en local avec `ModuleNotFoundError: No module named 'fastapi'` en raison d’une dépendance Python manquante, ce qui limite l’exécution automatique des tests ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff98dcf0c832ebeb2b9f8ce1bdc9f)