### PR TITLE
Clore les priorités hautes J1: non-régression frontend, CI actif/legacy et critères J2

### DIFF
--- a/CI-CD.md
+++ b/CI-CD.md
@@ -32,3 +32,25 @@ docker build -f Dockerfile.j3 -t openindex-j3:local .
 docker compose -f docker-compose.j3.yml up -d
 curl -f http://localhost:8000/health
 ```
+
+
+## Matrice de décision (actif vs legacy)
+
+| Chaîne | Statut | Usage attendu | Action |
+|---|---|---|---|
+| `.github/workflows/docker-j3.yml` | **Active** | Build/publish images crawler+UI pour la stack courante | Référence unique pour validations CI J1/J2 |
+| `.gitea/workflows/ci.yml` | **Legacy** | Historique, compatibilité infra Gitea non cible | Ne pas utiliser comme source de vérité; maintenance minimale |
+
+## Critères de sortie J1 vers entrée J2
+
+### Sortie J1 (DoD)
+
+- Documentation de pilotage alignée (`README`, `ROADMAP`, `TODO`, `CI-CD`, `docs/WORKFLOW`).
+- Contrôles critiques automatisés disponibles (API smoke + non-régression frontend structurelle).
+- Distinction explicite entre workflows CI actifs et legacy actée dans la documentation.
+
+### Entrée J2 (gating)
+
+- Exécution reproductible de la suite de smoke tests en local/CI.
+- Règles de contribution orientées stack active (FastAPI + frontend + SQLite) explicites.
+- Backlog J2 priorisé sur fiabilisation (tests, incident, exploitation).

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@
 
 ## Priorité haute
 
-- [ ] Ajouter un scénario de non-régression frontend sur les vues principales.
-- [ ] Clarifier les workflows CI actifs vs legacy dans le dépôt.
-- [ ] Définir les critères de sortie J1 et entrée J2.
+- [x] Ajouter un scénario de non-régression frontend sur les vues principales.
+- [x] Clarifier les workflows CI actifs vs legacy dans le dépôt.
+- [x] Définir les critères de sortie J1 et entrée J2.
 
 ## Préparation J2/J3
 

--- a/docs/PROTOCOLES_AUTOMATISES.md
+++ b/docs/PROTOCOLES_AUTOMATISES.md
@@ -17,3 +17,20 @@
 ## Écart actuel
 
 Les workflows legacy existent encore; la référence opérationnelle doit rester la chaîne J3.
+
+
+## Scénario non-régression frontend (vues principales)
+
+Objectif: garantir la présence des vues clés et de leurs bindings Alpine.
+
+- Vues contrôlées: `dashboard`, `files`, `duplicates`, `monitoring`.
+- Vérifications minimales:
+  - présence du déclencheur `currentView = ...` dans la navigation,
+  - présence du conteneur de vue `x-show="currentView === ..."`,
+  - présence des libellés utilisateur associés (Tableau de bord, Fichiers, Doublons, Monitoring).
+
+Commande recommandée:
+
+```bash
+pytest -q tests/test_frontend_structure.py
+```

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -20,3 +20,21 @@ Toute évolution de stack doit être répercutée au minimum dans :
 
 - Prioritaire : GitHub workflow `docker-j3.yml`.
 - Legacy : `.gitea/workflows/ci.yml` (à maintenir séparément de la doc active).
+
+
+## Workflows CI actifs vs legacy
+
+- **Actif (référence)** : `.github/workflows/docker-j3.yml` pour build et publication des images de la stack courante.
+- **Legacy (compatibilité)** : `.gitea/workflows/ci.yml` conservé pour historique/infrastructures non cibles J1-J2.
+- En cas de divergence, la décision opérationnelle est prise sur le workflow GitHub J3.
+
+## Critères de passage J1 -> J2
+
+### J1 validé si
+- Les priorités critiques et hautes du `TODO.md` sont clôturées.
+- Les checks API critiques et le scénario de non-régression frontend passent localement.
+- Les workflows actifs vs legacy sont clairement documentés.
+
+### J2 démarre avec
+- Un backlog fiabilisation testable (tests API/front, protocole incident, exploitation).
+- Une cadence de validation standard (tests + revue + PR) appliquée à chaque lot.

--- a/tests/test_frontend_structure.py
+++ b/tests/test_frontend_structure.py
@@ -17,3 +17,19 @@ def test_frontend_uses_realtime_and_chart_libs():
     assert "chart.js" in html.lower()
     assert "WebSocket" in html
     assert "crawlChart" in html
+
+
+def test_frontend_main_views_non_regression_scenario():
+    html = Path("frontend/index.html").read_text(encoding="utf-8")
+
+    expected_views = {
+        "dashboard": "Tableau de bord",
+        "files": "Fichiers",
+        "duplicates": "Doublons",
+        "monitoring": "Monitoring",
+    }
+
+    for view_key, view_label in expected_views.items():
+        assert f"currentView = '{view_key}'" in html
+        assert view_label in html
+        assert f"x-show=\"currentView === '{view_key}'\"" in html


### PR DESCRIPTION
### Motivation

- Fermer les items de Priorité haute du `TODO.md` en garantissant une non-régression frontend minimale, clarifier l’état des pipelines CI et définir des gates pour passer de J1 à J2.

### Description

- Ajoute un scénario de non-régression frontend dans `tests/test_frontend_structure.py` qui vérifie la présence des vues `dashboard`, `files`, `duplicates` et `monitoring` ainsi que leurs bindings `currentView` et `x-show`.
- Documente la matrice décisionnelle CI actif vs legacy et les critères de sortie J1 / entrée J2 dans `CI-CD.md` et `docs/WORKFLOW.md`.
- Ajoute le protocole de non-régression frontend dans `docs/PROTOCOLES_AUTOMATISES.md` et recommande la commande de validation `pytest -q tests/test_frontend_structure.py`.
- Met à jour `TODO.md` en cochant les trois items de priorité haute désormais traités.

### Testing

- Exécution des tests de non-régression frontend via `pytest -q tests/test_frontend_structure.py` qui a réussi avec `3 passed`.
- Aucune autre suite automatique modifiée; les changements sont principalement documentaires et ajout d’un test structurel frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69affcd7105c832e99528abc77afdb40)