### PR TITLE
docs: compléter TODO J2/J3 avec la suite commando

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO OpenIndex — J1
+# TODO OpenIndex — J1 à J3
 
 ## Priorité critique (J1)
 
@@ -6,17 +6,37 @@
 - [x] Valider un jeu de tests reproductible API (`/health`, `/api/stats`, `/api/files`, `/api/db-explain`).
 - [x] Décrire la procédure de reprise sur incident SQLite (absence/corruption).
 
-## Priorité haute
+## Priorité haute (J1)
 
 - [x] Ajouter un scénario de non-régression frontend sur les vues principales.
 - [x] Clarifier les workflows CI actifs vs legacy dans le dépôt.
 - [x] Définir les critères de sortie J1 et entrée J2.
 
-## Préparation J2/J3
+## Préparation J2/J3 (finalisée)
 
-- [ ] Formaliser les SLO minimaux API (latence, erreurs, disponibilité).
-- [ ] Préparer plan de test de charge sur volumétrie représentative.
-- [ ] Lister les prérequis techniques pour la consolidation PostgreSQL.
+- [x] Formaliser les SLO minimaux API (latence, erreurs, disponibilité) via KPI commando et critères go/no-go.
+- [x] Préparer un plan de test de charge et benchmark comparatif SQLite vs PostgreSQL.
+- [x] Lister les prérequis techniques pour la consolidation PostgreSQL (adaptateur parallèle, dry-run, rollback, CI dual DB).
+
+## Suite (issue des docs / option commando)
+
+### Semaine 1 — Stabilisation exécutable J3
+
+- [ ] CMD-01 — Standardiser l'environnement de test (requirements/dev + script unique).
+- [ ] CMD-02 — Fiabiliser les tests API critiques et éliminer la flakiness.
+- [ ] CMD-03 — Renforcer la non-régression frontend sur les vues clés.
+- [ ] CMD-04 — Tester le runbook incident SQLite et mesurer le temps de recovery.
+- [ ] CMD-05 — Documenter une CI de référence unique (J3) + conventions de merge.
+- [ ] CMD-06 — Ajouter la section "limitations connues" dans la documentation principale.
+
+### Semaine 2 — Readiness J4 sans big bang
+
+- [ ] CMD-07 — Définir les critères go/no-go J3 -> J4 (perf, rollback, migration).
+- [ ] CMD-08 — Introduire l'adaptateur PostgreSQL en mode parallèle (feature flag).
+- [ ] CMD-09 — Écrire et valider le dry-run de migration J3 -> J4.
+- [ ] CMD-10 — Publier un bench comparatif SQLite vs PostgreSQL (P95 endpoints critiques).
+- [ ] CMD-11 — Étendre la CI pour couvrir SQLite + PostgreSQL (matrice dual DB).
+- [ ] CMD-12 — Préparer la checklist de release commando.
 
 ## Fait (lancement J1)
 


### PR DESCRIPTION
### Motivation
- Finaliser la section de préparation J2/J3 dans `TODO.md` pour refléter l’état décrit dans la documentation opérationnelle. 
- Rendre le TODO opérationnel en y intégrant la suite d’actions issues de `docs/OPTION_COMMANDO.md` pour piloter le travail court terme (stabilisation J3 puis readiness J4).

### Description
- Renommage du titre en `# TODO OpenIndex — J1 à J3` pour clarifier la période couverte. 
- Marquage des éléments de `Préparation J2/J3` comme finalisés et précision des livrables (SLO, plan de charge/benchmark, prérequis PostgreSQL). 
- Ajout de la section "Suite (issue des docs / option commando)" contenant le backlog structuré en 2 semaines avec les tickets `CMD-01` à `CMD-12` (Semaine 1: stabilisation exécutable J3, Semaine 2: readiness J4). 
- Ajustement de l’en-tête Priorité haute en `Priorité haute (J1)` pour cohérence contextuelle.

### Testing
- Vérification du contenu final avec `nl -ba TODO.md | sed -n '1,260p'` pour s’assurer de la présence et de l’ordre des sections ajoutées. 
- Vérification du diff ciblé sur `TODO.md` pour confirmer les insertions et suppressions prévues. 
- Inspection rapide du fichier modifié pour s’assurer qu’aucune autre section du dépôt n’a été impactée par le changement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69affe1b7aa0832e99f575d31a1e5599)