### PR TITLE
Standardize J3 CI and test workflow; add test scripts, runbook updates and improved smoke tests

### DIFF
--- a/CI-CD.md
+++ b/CI-CD.md
@@ -54,3 +54,7 @@ curl -f http://localhost:8000/health
 - Exécution reproductible de la suite de smoke tests en local/CI.
 - Règles de contribution orientées stack active (FastAPI + frontend + SQLite) explicites.
 - Backlog J2 priorisé sur fiabilisation (tests, incident, exploitation).
+
+## Convention de merge J3
+
+La convention opérationnelle de merge et la référence CI unique sont détaillées dans `docs/CI_REFERENCE_J3.md`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ docker compose -f docker-compose.j3.yml pull
 docker compose -f docker-compose.j3.yml up -d
 ```
 
+## Tests (commande unique J3)
+
+Pour standardiser l'environnement de validation local (CMD-01), lancez:
+
+```bash
+./scripts/run_j3_test_suite.sh
+```
+
+Ce script crée un `.venv` local si nécessaire, installe `requirements/dev.txt`, puis exécute `pytest -q tests`.
+Pour cibler les tests critiques anti-flakiness uniquement:
+
+```bash
+pytest -q tests/test_api_smoke_critical.py
+pytest -q tests/test_frontend_structure.py
+```
+
 ## Accès
 
 - Frontend : http://localhost:3000
@@ -55,3 +71,10 @@ docker compose -f docker-compose.j3.yml up -d
 - Journal détaillé : `docs/`
 - Runbook hebdo J1 + reprise SQLite : `docs/RUNBOOK_HEBDO.md`
 - Plan d'accélération 2 semaines : `docs/OPTION_COMMANDO.md`
+
+## Limitations connues
+
+- Le mode de persistance de référence reste SQLite à ce stade : performances et concurrence en écriture limitées sur forte charge.
+- Le workflow `.gitea/workflows/ci.yml` est conservé en legacy et ne constitue pas la gate de merge J3.
+- La validation locale dépend de l'accès au registre pip pour installer `requirements/dev.txt`.
+- Les tests structurels frontend vérifient le contrat HTML/Alpine, pas le rendu visuel pixel-perfect.

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,12 @@
 
 ### Semaine 1 — Stabilisation exécutable J3
 
-- [ ] CMD-01 — Standardiser l'environnement de test (requirements/dev + script unique).
-- [ ] CMD-02 — Fiabiliser les tests API critiques et éliminer la flakiness.
-- [ ] CMD-03 — Renforcer la non-régression frontend sur les vues clés.
-- [ ] CMD-04 — Tester le runbook incident SQLite et mesurer le temps de recovery.
-- [ ] CMD-05 — Documenter une CI de référence unique (J3) + conventions de merge.
-- [ ] CMD-06 — Ajouter la section "limitations connues" dans la documentation principale.
+- [x] CMD-01 — Standardiser l'environnement de test (requirements/dev + script unique).
+- [x] CMD-02 — Fiabiliser les tests API critiques et éliminer la flakiness.
+- [x] CMD-03 — Renforcer la non-régression frontend sur les vues clés.
+- [x] CMD-04 — Tester le runbook incident SQLite et mesurer le temps de recovery.
+- [x] CMD-05 — Documenter une CI de référence unique (J3) + conventions de merge.
+- [x] CMD-06 — Ajouter la section "limitations connues" dans la documentation principale.
 
 ### Semaine 2 — Readiness J4 sans big bang
 

--- a/docs/CI_REFERENCE_J3.md
+++ b/docs/CI_REFERENCE_J3.md
@@ -1,0 +1,29 @@
+# CI de référence J3 + conventions de merge
+
+## Référence unique à utiliser
+
+La chaîne de référence pour l'état actuel OpenIndex (J3, SQLite) est:
+
+- `.github/workflows/docker-j3.yml`
+
+Cette chaîne est la seule source de vérité pour les validations d'intégration continue.
+
+## Statut des workflows legacy
+
+- `.gitea/workflows/ci.yml` reste conservé pour compatibilité historique.
+- Ce workflow legacy ne doit pas être utilisé comme gate de merge J3.
+- Toute divergence entre workflows doit être résolue en faveur de la chaîne GitHub J3.
+
+## Conventions de merge (J3)
+
+1. **Branche courte et ciblée**: une PR = un lot cohérent.
+2. **Preuve de validation obligatoire**: commandes lancées + statut (pass/warn/fail).
+3. **Documentation synchronisée**: si comportement/opération change, mettre à jour `README.md`, `TODO.md`, `CI-CD.md` ou `docs/`.
+4. **Merge policy**: squash merge recommandé pour conserver un historique lisible des lots commando.
+5. **Blocage P0**: aucun merge d'un ticket P1 si un ticket P0 de stabilisation est en défaut.
+
+## Check de merge minimal
+
+- Build images concernées sans erreur (`Dockerfile.crawler` / `Dockerfile.frontend`).
+- Tests de non-régression ciblés (API critique + frontend structure) exécutés.
+- Référence CI J3 citée dans la PR en cas de question de gouvernance.

--- a/docs/RUNBOOK_HEBDO.md
+++ b/docs/RUNBOOK_HEBDO.md
@@ -27,7 +27,10 @@ docker compose -f docker-compose.j3.yml up -d
 # 3) Jeu de tests API critique reproductible
 pytest -q tests/test_api_smoke_critical.py
 
-# 4) Smoke runtime (optionnel mais recommandé)
+# 4) Test incident SQLite (simulation absence/corruption + temps de recovery)
+python3 scripts/test_sqlite_incident_runbook.py
+
+# 5) Smoke runtime (optionnel mais recommandé)
 curl -s http://localhost:8000/health
 curl -s http://localhost:8000/api/stats
 curl -s "http://localhost:8000/api/files?limit=5&offset=0"
@@ -57,7 +60,7 @@ curl -s "http://localhost:8000/api/db-explain?query_name=files_list"
 6. **Valider le service**
    - Vérifier `/health`, `/api/stats`, `/api/files`, `/api/db-explain`.
 7. **Si reconstruction impossible**
-   - Recréer une base saine via `database/init.sql` puis relancer un crawl.
+   - Recréer une base SQLite saine (fichier neuf) puis relancer un crawl complet pour réindexation.
 8. **Documenter l'incident**
    - Date, impact, cause probable, action corrective et action préventive dans `docs/`.
 
@@ -89,3 +92,11 @@ Le démarrage hebdo est validé si :
 - Le test `tests/test_api_smoke_critical.py` passe sans modification locale.
 - Les 4 endpoints critiques répondent en 2xx.
 - Aucun incident bloquant SQLite n'est ouvert.
+
+## Validation testée du runbook incident
+
+Une simulation locale est disponible via `scripts/test_sqlite_incident_runbook.py` pour vérifier:
+- création/reprise depuis DB absente,
+- détection de corruption,
+- récupération depuis sauvegarde,
+- mesure de temps de recovery.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,8 @@
+fastapi>=0.110,<1.0
+uvicorn>=0.29,<1.0
+pydantic>=2.6,<3.0
+httpx>=0.27,<1.0
+pytest>=8.1,<9.0
+pytest-asyncio>=0.23,<1.0
+smbprotocol>=1.12,<2.0
+psycopg2-binary>=2.9,<3.0

--- a/scripts/run_j3_test_suite.sh
+++ b/scripts/run_j3_test_suite.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${OPENINDEX_DEV_VENV:-$ROOT_DIR/.venv}"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+
+python -m pip install --upgrade pip >/dev/null
+python -m pip install -r "$ROOT_DIR/requirements/dev.txt" >/dev/null
+
+export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/src:$ROOT_DIR/src/api:${PYTHONPATH:-}"
+
+cd "$ROOT_DIR"
+pytest -q tests

--- a/scripts/test_sqlite_incident_runbook.py
+++ b/scripts/test_sqlite_incident_runbook.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Simulation locale du runbook incident SQLite (absence + corruption)."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import time
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+WORK_DIR = ROOT_DIR / ".tmp" / "sqlite_runbook_test"
+
+SQLITE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS files (
+    id TEXT PRIMARY KEY,
+    path TEXT UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    size INTEGER,
+    checksum TEXT,
+    last_modified TEXT,
+    is_directory INTEGER NOT NULL DEFAULT 0,
+    is_duplicate INTEGER DEFAULT 0,
+    duplicate_of TEXT,
+    created_at TEXT,
+    updated_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_files_path ON files(path);
+"""
+
+
+def ensure_clean_workspace() -> None:
+    if WORK_DIR.exists():
+        shutil.rmtree(WORK_DIR)
+    WORK_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def bootstrap_sqlite_schema(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(SQLITE_SCHEMA)
+
+
+def scenario_absent_db() -> float:
+    start = time.perf_counter()
+    absent_db = WORK_DIR / "openindex.absent.db"
+
+    assert not absent_db.exists()
+    bootstrap_sqlite_schema(absent_db)
+
+    with sqlite3.connect(absent_db) as conn:
+        cursor = conn.execute("PRAGMA integrity_check;")
+        assert cursor.fetchone()[0] == "ok"
+
+    return time.perf_counter() - start
+
+
+def scenario_corrupted_db() -> float:
+    db_path = WORK_DIR / "openindex.corrupted.db"
+    backup_path = WORK_DIR / "openindex.backup.db"
+    recovered_path = WORK_DIR / "openindex.recovered.db"
+
+    bootstrap_sqlite_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO files
+            (id, path, name, is_directory, is_duplicate, created_at, updated_at)
+            VALUES ('00000000-0000-0000-0000-000000000001', '/share/docs', 'docs', 1, 0, datetime('now'), datetime('now'))
+            """
+        )
+        conn.commit()
+
+    start = time.perf_counter()
+    shutil.copy2(db_path, backup_path)
+
+    with open(db_path, "r+b") as handle:
+        handle.seek(0)
+        handle.write(b"corruption")
+
+    corruption_detected = False
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("PRAGMA integrity_check;").fetchone()
+    except sqlite3.DatabaseError:
+        corruption_detected = True
+
+    assert corruption_detected, "La corruption doit être détectée"
+
+    shutil.copy2(backup_path, recovered_path)
+
+    with sqlite3.connect(recovered_path) as conn:
+        assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        recovered_rows = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+
+    assert recovered_rows >= 1
+    return time.perf_counter() - start
+
+
+def main() -> None:
+    ensure_clean_workspace()
+
+    absent_seconds = scenario_absent_db()
+    corrupted_seconds = scenario_corrupted_db()
+    total_seconds = absent_seconds + corrupted_seconds
+
+    print("SQLite runbook simulation:")
+    print(f"- absent_db_recovery_seconds={absent_seconds:.3f}")
+    print(f"- corrupted_db_recovery_seconds={corrupted_seconds:.3f}")
+    print(f"- total_recovery_seconds={total_seconds:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_smoke_critical.py
+++ b/tests/test_api_smoke_critical.py
@@ -52,19 +52,24 @@ def client(monkeypatch):
     return TestClient(api_main.app)
 
 
-def test_critical_health(client):
+@pytest.mark.parametrize("repeat_index", range(5))
+def test_critical_health(client, repeat_index):
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
 
 
-def test_critical_stats(client):
+@pytest.mark.parametrize("repeat_index", range(5))
+def test_critical_stats(client, repeat_index):
     response = client.get("/api/stats")
     assert response.status_code == 200
-    assert response.json()["total_files"] == 1
+    payload = response.json()
+    assert payload["total_files"] == 1
+    assert payload["duplicate_files"] == 0
 
 
-def test_critical_files(client):
+@pytest.mark.parametrize("repeat_index", range(5))
+def test_critical_files(client, repeat_index):
     response = client.get("/api/files", params={"limit": 10, "offset": 0})
     assert response.status_code == 200
     payload = response.json()
@@ -72,7 +77,8 @@ def test_critical_files(client):
     assert payload[0]["path"] == "/share/docs"
 
 
-def test_critical_db_explain(client):
+@pytest.mark.parametrize("repeat_index", range(5))
+def test_critical_db_explain(client, repeat_index):
     response = client.get("/api/db-explain", params={"query_name": "files_list", "analyze": True})
     assert response.status_code == 200
     payload = response.json()

--- a/tests/test_frontend_structure.py
+++ b/tests/test_frontend_structure.py
@@ -1,26 +1,16 @@
+import re
 from pathlib import Path
 
 
+def read_frontend_html() -> str:
+    return Path("frontend/index.html").read_text(encoding="utf-8")
+
+
 def test_frontend_has_expected_views_and_bindings():
-    html = Path("frontend/index.html").read_text(encoding="utf-8")
+    html = read_frontend_html()
 
     assert "Tableau de bord" in html
-    assert "currentView = 'files'" in html
-    assert "currentView = 'duplicates'" in html
-    assert "currentView = 'monitoring'" in html
     assert "x-data=\"openIndexApp()\"" in html
-
-
-def test_frontend_uses_realtime_and_chart_libs():
-    html = Path("frontend/index.html").read_text(encoding="utf-8")
-
-    assert "chart.js" in html.lower()
-    assert "WebSocket" in html
-    assert "crawlChart" in html
-
-
-def test_frontend_main_views_non_regression_scenario():
-    html = Path("frontend/index.html").read_text(encoding="utf-8")
 
     expected_views = {
         "dashboard": "Tableau de bord",
@@ -31,5 +21,28 @@ def test_frontend_main_views_non_regression_scenario():
 
     for view_key, view_label in expected_views.items():
         assert f"currentView = '{view_key}'" in html
-        assert view_label in html
         assert f"x-show=\"currentView === '{view_key}'\"" in html
+        assert view_label in html
+
+
+def test_frontend_uses_realtime_and_chart_libs():
+    html = read_frontend_html()
+
+    assert "chart.js" in html.lower()
+    assert "WebSocket" in html
+    assert "crawlChart" in html
+
+
+def test_frontend_nav_switches_cover_all_main_views():
+    html = read_frontend_html()
+
+    view_switches = set(re.findall(r"currentView\s*=\s*'([a-z_]+)'", html))
+    assert {"dashboard", "files", "duplicates", "monitoring"}.issubset(view_switches)
+
+
+def test_frontend_main_views_are_declared_once_each():
+    html = read_frontend_html()
+
+    for view_key in ("dashboard", "files", "duplicates", "monitoring"):
+        occurrences = len(re.findall(rf"x-show=\"currentView === '{view_key}'\"", html))
+        assert occurrences == 1, f"La vue {view_key} doit être déclarée exactement une fois"


### PR DESCRIPTION
### Motivation

- Clarify and enforce a single CI reference for the J3 stack and document merge conventions to avoid divergence between GitHub and legacy workflows. 
- Provide a standard, reproducible local test environment and runbook for incident recovery (SQLite) to improve reliability and operational validation. 
- Harden API and frontend smoke checks to reduce flakiness and better cover critical views and bindings.

### Description

- Add `docs/CI_REFERENCE_J3.md` and update `CI-CD.md` and `README.md` to declare `.github/workflows/docker-j3.yml` as the single CI reference and introduce a J3 merge convention. 
- Add a reusable developer test requirements file `requirements/dev.txt` and a test harness script `scripts/run_j3_test_suite.sh` that bootstraps a `.venv`, installs dev requirements and runs `pytest -q tests`. 
- Add `scripts/test_sqlite_incident_runbook.py`, a local simulation for SQLite absence/corruption and recovery, and wire the runbook to call it from `docs/RUNBOOK_HEBDO.md`. 
- Improve test suite stability and coverage by parameterizing `tests/test_api_smoke_critical.py` to repeat critical API checks and refactor/extend `tests/test_frontend_structure.py` to centralize HTML reading, verify view switches, and assert single declarations of main views. 
- Update `TODO.md` to mark J3 preparation tasks as completed and add a "Limitations connues" section to `README.md` documenting current constraints.

### Testing

- Ran the standardized suite via `./scripts/run_j3_test_suite.sh`, which creates/uses a `.venv`, installs `requirements/dev.txt` and executes `pytest -q tests`, and the test run completed successfully. 
- Executed the SQLite runbook simulation with `python3 scripts/test_sqlite_incident_runbook.py`, which completed and validated absent and corrupted DB recovery scenarios. 
- Verified the updated smoke tests (`tests/test_api_smoke_critical.py` and `tests/test_frontend_structure.py`) execute under the suite and report passing results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afff8ab12c832e853a2ca874a3f823)