### PR TITLE
nginx: proxy /api and /ws to FastAPI backend to restore UI connectivity

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -47,16 +47,24 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
-        # API non exposée dans cette stack minimale (UI + crawler + PostgreSQL)
+        # Proxy API FastAPI
         location /api/ {
-            return 501 "API service not enabled in this compose profile\n";
-            add_header Content-Type text/plain;
+            proxy_pass http://api:8000/api/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # WebSocket non exposé dans cette stack minimale
+        # Proxy WebSocket FastAPI
         location /ws {
-            return 501 "WebSocket service not enabled in this compose profile\n";
-            add_header Content-Type text/plain;
+            proxy_pass http://api:8000/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_read_timeout 60s;
         }
 
         # Health check


### PR DESCRIPTION
### Motivation
- The UI calls `/api/*` and `/ws` but nginx was returning `501`, making the frontend non-functional when served through the stack.
- The change is intended to restore connectivity by forwarding API and WebSocket requests to the FastAPI service in the compose topology.

### Description
- Updated `nginx/nginx.conf` to proxy `/api/` to `http://api:8000/api/` and forward standard headers (`proxy_set_header Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`).
- Updated `nginx/nginx.conf` to proxy `/ws` to `http://api:8000/ws` with WebSocket upgrade headers (`Upgrade`/`Connection`) and increased `proxy_read_timeout` for stability.
- Replaced the previous static `501` responses for `location /api/` and `location /ws` with reverse-proxy directives so the UI can communicate with the backend when running via `docker-compose`.

### Testing
- Ran frontend structure tests with `pytest -q tests/test_frontend_structure.py` which passed (4 passed).
- Attempted to run API tests (`pytest -q tests/test_frontend_structure.py tests/test_api_fastapi.py`) but test collection failed due to missing `fastapi` dependency in the environment.
- Installing dev dependencies with `pip install -r requirements/dev.txt` failed due to network/proxy restrictions preventing download of `fastapi` and other packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0264a79dc832e9f98cd40793ff88f)