### PR TITLE
Implémentation rapide: ajout/paramétrage des crawls (paths, credentials, zone de domaine)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,6 +139,12 @@
                         <i class="fas fa-database mr-3"></i>
                         DB Explain
                     </a>
+                    <a href="#" @click="currentView = 'implementation'" 
+                       class="flex items-center px-4 py-2 text-sm font-medium rounded-lg hover:bg-gray-100"
+                       :class="currentView === 'implementation' ? 'bg-blue-50 text-blue-700' : 'text-gray-700'">
+                        <i class="fas fa-rocket mr-3"></i>
+                        Implémentation rapide
+                    </a>
                 </nav>
             </div>
         </aside>
@@ -358,6 +364,78 @@
                     </div>
                 </div>
 
+
+                <!-- Vue Implémentation rapide -->
+                <div x-show="currentView === 'implementation'" class="fade-in">
+                    <h2 class="text-2xl font-bold text-gray-900 mb-6">⚡ Implémentation rapide</h2>
+
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div class="card p-6">
+                            <h3 class="text-lg font-medium text-gray-900 mb-4">Ajouter un crawl</h3>
+                            <form @submit.prevent="createCrawlConfig()" class="space-y-4">
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Nom du crawl</label>
+                                    <input type="text" x-model="newCrawl.name" required class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Zone de domaine</label>
+                                    <input type="text" x-model="newCrawl.domain_zone" placeholder="EMEA / EU / FR" required class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Path de départ</label>
+                                    <input type="text" x-model="newCrawl.start_path" placeholder="\\server\share" required class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Paths inclus (un par ligne)</label>
+                                    <textarea x-model="newCrawl.includePathsText" rows="3" class="w-full border border-gray-300 rounded-lg px-3 py-2"></textarea>
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Paths exclus (un par ligne)</label>
+                                    <textarea x-model="newCrawl.excludePathsText" rows="3" class="w-full border border-gray-300 rounded-lg px-3 py-2"></textarea>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 mb-1">Utilisateur</label>
+                                        <input type="text" x-model="newCrawl.connection.username" required class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                    </div>
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 mb-1">Mot de passe</label>
+                                        <input type="password" x-model="newCrawl.connection.password" required class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                    </div>
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 mb-1">Domaine</label>
+                                        <input type="text" x-model="newCrawl.connection.domain" placeholder="CORP" class="w-full border border-gray-300 rounded-lg px-3 py-2">
+                                    </div>
+                                </div>
+                                <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg">
+                                    <i class="fas fa-plus mr-2"></i>Créer la configuration
+                                </button>
+                            </form>
+                        </div>
+
+                        <div class="card p-6">
+                            <h3 class="text-lg font-medium text-gray-900 mb-4">Configurations disponibles</h3>
+                            <button @click="loadCrawlConfigs()" class="mb-4 bg-gray-100 hover:bg-gray-200 px-3 py-2 rounded-lg text-sm">Rafraîchir</button>
+                            <div x-show="crawlConfigs.length === 0" class="text-sm text-gray-500">Aucune configuration pour le moment.</div>
+                            <div class="space-y-3" x-show="crawlConfigs.length > 0">
+                                <template x-for="config in crawlConfigs" :key="config.id">
+                                    <div class="border border-gray-200 rounded-lg p-4">
+                                        <div class="flex items-center justify-between">
+                                            <div>
+                                                <p class="font-medium text-gray-900" x-text="config.name"></p>
+                                                <p class="text-xs text-gray-500" x-text="`Zone: ${config.domain_zone} • Départ: ${config.start_path}`"></p>
+                                                <p class="text-xs text-gray-500" x-text="`Compte: ${config.connection_domain || '-'}\\${config.connection_username}`"></p>
+                                            </div>
+                                            <button @click="startCrawl(config.id)" class="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded-lg text-sm">Lancer</button>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                            <p x-show="implementationStatus" class="mt-4 text-sm text-blue-700" x-text="implementationStatus"></p>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Vue Analyse DB -->
                 <div x-show="currentView === 'dbAnalysis'" class="fade-in">
                     <div class="flex justify-between items-center mb-6">
@@ -415,6 +493,20 @@
                 dbExplainError: '',
                 spaces: [],
                 activeSpace: '',
+                crawlConfigs: [],
+                implementationStatus: '',
+                newCrawl: {
+                    name: '',
+                    domain_zone: '',
+                    start_path: '',
+                    includePathsText: '',
+                    excludePathsText: '',
+                    connection: {
+                        username: '',
+                        password: '',
+                        domain: ''
+                    }
+                },
                 
                 async init() {
                     await this.loadSpaces();
@@ -430,6 +522,7 @@
                     } else if (this.currentView === 'dbAnalysis') {
                         this.loadDbExplain();
                     }
+                    await this.loadCrawlConfigs();
                 },
                 
                 toggleSidebar() {
@@ -508,6 +601,67 @@
                     }
                 },
                 
+
+
+                async loadCrawlConfigs() {
+                    try {
+                        const response = await fetch('/api/crawl-configs');
+                        this.crawlConfigs = await response.json();
+                    } catch (error) {
+                        console.error('Erreur configs crawl:', error);
+                    }
+                },
+
+                async createCrawlConfig() {
+                    try {
+                        const payload = {
+                            name: this.newCrawl.name,
+                            domain_zone: this.newCrawl.domain_zone,
+                            start_path: this.newCrawl.start_path,
+                            include_paths: this.newCrawl.includePathsText.split('\n').map(line => line.trim()).filter(Boolean),
+                            exclude_paths: this.newCrawl.excludePathsText.split('\n').map(line => line.trim()).filter(Boolean),
+                            connection: {
+                                username: this.newCrawl.connection.username,
+                                password: this.newCrawl.connection.password,
+                                domain: this.newCrawl.connection.domain || null
+                            }
+                        };
+                        const response = await fetch('/api/crawl-configs', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        });
+                        if (!response.ok) {
+                            throw new Error('Création impossible');
+                        }
+                        const created = await response.json();
+                        this.implementationStatus = `Configuration créée: ${created.name}`;
+                        this.newCrawl = {
+                            name: '', domain_zone: '', start_path: '', includePathsText: '', excludePathsText: '',
+                            connection: { username: '', password: '', domain: '' }
+                        };
+                        await this.loadCrawlConfigs();
+                    } catch (error) {
+                        this.implementationStatus = `Erreur: ${error.message}`;
+                    }
+                },
+
+                async startCrawl(configId) {
+                    try {
+                        const response = await fetch('/api/crawls/start', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ config_id: configId })
+                        });
+                        if (!response.ok) {
+                            throw new Error('Démarrage impossible');
+                        }
+                        const run = await response.json();
+                        this.implementationStatus = `Crawl ${run.run_id} en statut ${run.status}`;
+                    } catch (error) {
+                        this.implementationStatus = `Erreur: ${error.message}`;
+                    }
+                },
 
                 async loadDbExplain() {
                     this.loadingDbExplain = true;

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 from datetime import datetime
+from uuid import uuid4
 
 try:
     import psycopg2
@@ -82,6 +83,44 @@ class ExplainPlan(BaseModel):
     query_name: str
     analyze: bool
     plan: List[str]
+
+
+class CrawlConnectionConfig(BaseModel):
+    username: str
+    password: str
+    domain: Optional[str] = None
+
+
+class CrawlConfigCreate(BaseModel):
+    name: str
+    domain_zone: str
+    start_path: str
+    include_paths: List[str] = []
+    exclude_paths: List[str] = []
+    connection: CrawlConnectionConfig
+
+
+class CrawlConfigPublic(BaseModel):
+    id: str
+    name: str
+    domain_zone: str
+    start_path: str
+    include_paths: List[str]
+    exclude_paths: List[str]
+    connection_username: str
+    connection_domain: Optional[str] = None
+    created_at: str
+
+
+class CrawlStartRequest(BaseModel):
+    config_id: str
+
+
+class CrawlRun(BaseModel):
+    run_id: str
+    config_id: str
+    status: str
+    triggered_at: str
 
 
 def extract_space_prefix(path: str) -> Optional[str]:
@@ -257,6 +296,9 @@ EXPLAIN_QUERIES = {
     """,
 }
 
+CRAWL_CONFIGS: List[Dict[str, Any]] = []
+CRAWL_RUNS: List[Dict[str, Any]] = []
+
 
 @app.get("/health")
 async def health_check():
@@ -421,6 +463,47 @@ async def get_db_explain(query_name: str = "files_list", analyze: bool = True):
     except Exception as e:
         logger.error(f"Erreur get_db_explain: {e}")
         raise HTTPException(status_code=500, detail="Erreur lors de la récupération du plan EXPLAIN")
+
+
+@app.get("/api/crawl-configs", response_model=List[CrawlConfigPublic])
+async def list_crawl_configs():
+    return [CrawlConfigPublic(**config) for config in CRAWL_CONFIGS]
+
+
+@app.post("/api/crawl-configs", response_model=CrawlConfigPublic)
+async def create_crawl_config(payload: CrawlConfigCreate):
+    config_id = str(uuid4())
+    config = {
+        "id": config_id,
+        "name": payload.name,
+        "domain_zone": payload.domain_zone,
+        "start_path": payload.start_path,
+        "include_paths": payload.include_paths,
+        "exclude_paths": payload.exclude_paths,
+        "connection_username": payload.connection.username,
+        "connection_domain": payload.connection.domain,
+        "created_at": datetime.now().isoformat(),
+        "_secret_password": payload.connection.password,
+    }
+    CRAWL_CONFIGS.append(config)
+    public_config = {key: value for key, value in config.items() if not key.startswith("_secret_")}
+    return CrawlConfigPublic(**public_config)
+
+
+@app.post("/api/crawls/start", response_model=CrawlRun)
+async def start_crawl(payload: CrawlStartRequest):
+    config = next((cfg for cfg in CRAWL_CONFIGS if cfg["id"] == payload.config_id), None)
+    if not config:
+        raise HTTPException(status_code=404, detail="Configuration de crawl introuvable")
+
+    run = {
+        "run_id": str(uuid4()),
+        "config_id": payload.config_id,
+        "status": "queued",
+        "triggered_at": datetime.now().isoformat(),
+    }
+    CRAWL_RUNS.append(run)
+    return CrawlRun(**run)
 
 
 @app.websocket("/ws")

--- a/tests/test_api_fastapi.py
+++ b/tests/test_api_fastapi.py
@@ -173,3 +173,61 @@ def test_get_db_explain_endpoint(client):
 def test_get_db_explain_invalid_query(client):
     response = client.get('/api/db-explain', params={'query_name': 'not_allowed'})
     assert response.status_code == 400
+
+
+def test_create_and_list_crawl_configs(client):
+    api_main.CRAWL_CONFIGS.clear()
+    payload = {
+        "name": "Crawl Finance",
+        "domain_zone": "EMEA",
+        "start_path": "\\\\srv\\finance",
+        "include_paths": ["\\\\srv\\finance\\public"],
+        "exclude_paths": ["\\\\srv\\finance\\temp"],
+        "connection": {
+            "username": "svc_finance",
+            "password": "secret",
+            "domain": "CORP",
+        },
+    }
+
+    create_response = client.post('/api/crawl-configs', json=payload)
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created['name'] == 'Crawl Finance'
+    assert 'connection_username' in created
+    assert '_secret_password' not in created
+
+    list_response = client.get('/api/crawl-configs')
+    assert list_response.status_code == 200
+    listed = list_response.json()
+    assert len(listed) == 1
+    assert listed[0]['domain_zone'] == 'EMEA'
+
+
+def test_start_crawl_requires_existing_config(client):
+    api_main.CRAWL_CONFIGS.clear()
+
+    missing = client.post('/api/crawls/start', json={'config_id': 'missing'})
+    assert missing.status_code == 404
+
+    created = client.post(
+        '/api/crawl-configs',
+        json={
+            "name": "Crawl RH",
+            "domain_zone": "FR",
+            "start_path": "\\\\srv\\rh",
+            "include_paths": [],
+            "exclude_paths": [],
+            "connection": {
+                "username": "svc_rh",
+                "password": "secret",
+                "domain": "CORP",
+            },
+        },
+    ).json()
+
+    started = client.post('/api/crawls/start', json={'config_id': created['id']})
+    assert started.status_code == 200
+    payload = started.json()
+    assert payload['status'] == 'queued'
+    assert payload['config_id'] == created['id']

--- a/tests/test_frontend_structure.py
+++ b/tests/test_frontend_structure.py
@@ -17,6 +17,7 @@ def test_frontend_has_expected_views_and_bindings():
         "files": "Fichiers",
         "duplicates": "Doublons",
         "monitoring": "Monitoring",
+        "implementation": "Implémentation rapide",
     }
 
     for view_key, view_label in expected_views.items():
@@ -37,12 +38,12 @@ def test_frontend_nav_switches_cover_all_main_views():
     html = read_frontend_html()
 
     view_switches = set(re.findall(r"currentView\s*=\s*'([a-z_]+)'", html))
-    assert {"dashboard", "files", "duplicates", "monitoring"}.issubset(view_switches)
+    assert {"dashboard", "files", "duplicates", "monitoring", "implementation"}.issubset(view_switches)
 
 
 def test_frontend_main_views_are_declared_once_each():
     html = read_frontend_html()
 
-    for view_key in ("dashboard", "files", "duplicates", "monitoring"):
+    for view_key in ("dashboard", "files", "duplicates", "monitoring", "implementation"):
         occurrences = len(re.findall(rf"x-show=\"currentView === '{view_key}'\"", html))
         assert occurrences == 1, f"La vue {view_key} doit être déclarée exactement une fois"


### PR DESCRIPTION
### Motivation
- Rendre l'UI immédiatement utile en ajoutant une phase d'implémentation rapide pour définir et lancer des crawls sans attendre l'intégration complète du moteur de crawl. 
- Permettre la configuration des chemins de crawl, des paths inclus/exclus et des credentials (utilisateur/mot de passe/domaine) par l'équipe d'exploitation.

### Description
- Ajoute des modèles Pydantic pour la gestion des crawls et des credentials : `CrawlConnectionConfig`, `CrawlConfigCreate`, `CrawlConfigPublic`, `CrawlStartRequest`, et `CrawlRun` dans `src/api/main.py`.
- Expose les nouveaux endpoints API en mémoire : `GET /api/crawl-configs`, `POST /api/crawl-configs` et `POST /api/crawls/start` et stocke temporairement les configs/runs dans `CRAWL_CONFIGS` et `CRAWL_RUNS` (in-memory) pour prototypage rapide.
- Étend le frontend `frontend/index.html` avec une nouvelle vue **Implémentation rapide** contenant un formulaire de création, la saisie des credentials, la zone de domaine, les include/exclude paths, la liste des configurations et un bouton `Lancer` qui appelle `POST /api/crawls/start`.
- Ajoute la logique Alpine.js pour charger/créer/configurer/démarrer des crawls (`loadCrawlConfigs`, `createCrawlConfig`, `startCrawl`) et met à jour les tests structurels et API pour couvrir ces flux.

### Testing
- `pytest -q tests/test_frontend_structure.py` a été exécuté et a réussi (4 passed). 
- `python -m py_compile src/api/main.py` a été exécuté et a réussi pour vérifier la validité syntaxique du module modifié. 
- L'exécution combinée `pytest -q tests/test_api_fastapi.py tests/test_frontend_structure.py` a échoué en collecte à cause d'un environnement de test manquant la dépendance `fastapi` (`ModuleNotFoundError: No module named 'fastapi'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b034061978832e8581429f6282eb93)