### PR TITLE
Finalize J4 Go decision after CI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,9 +19,9 @@ Passer d'une **readiness J4 documentée** à une **exécution J4 pilotée par pr
 - [x] **T-02 — Décision formelle Go/No-Go J4**
   - Appliquer les critères de `docs/phases/J4_MIGRATION.md`.
   - Décision rédigée le `2026-03-18` dans `docs/2026-03-18_j4_go-no-go.md`.
-  - Décision retenue: `No-Go`.
-  - Écarts bloquants listés: CI PostgreSQL non validée, rapport d'initialisation/recrawl absent, rollback pairé non prouvé, benchmark J4 incomplet.
-  - Commit: `0f63189`
+  - Décision retenue: `Go`.
+  - Preuves: recrawl contrôlé, benchmark 3 runs stable, rollback drill validé, CI GitHub PostgreSQL verte sur PR `#41`.
+  - Commit: `17f5806`
 
 - [ ] **T-03 — Figer la baseline technique J4**
   - Confirmer PostgreSQL comme backend de données unique dans la doc principale.

--- a/docs/2026-03-18_j4_execution_report.md
+++ b/docs/2026-03-18_j4_execution_report.md
@@ -2,6 +2,7 @@
 
 Date: 2026-03-18
 Périmètre: exécution contrôlée J4 sur cible SMB `\\172.16.252.34\Public\SMIDEN`
+Statut final: Go
 
 ## Résumé
 
@@ -81,7 +82,13 @@ Critères:
 - Initialisation + recrawl journalisés: `OK`
 - Rollback testé: `OK`
 - Rollback validé par le responsable opérationnel: `OK`
-- CI PostgreSQL de référence: tests locaux `OK`, statut CI hébergé non prouvé dans le dépôt
+- CI PostgreSQL de référence: `OK`
+
+Preuve CI:
+- PR GitHub: `#41` `https://github.com/lamacheref/openindex/pull/41`
+- Workflow: `Docker Stack CI`
+- Job PostgreSQL: `api-tests-postgresql` en statut `pass`
+- Artefact versionné: `docs/artifacts/j4_ci_pr41_2026-03-18.json`
 
 Décision opérationnelle:
-- Le statut global reste `No-Go` tant que la validation pair du rollback et la preuve CI PostgreSQL hébergée ne sont pas closes.
+- Le statut global passe à `Go` pour l'environnement de validation du 2026-03-18.

--- a/docs/2026-03-18_j4_go-no-go.md
+++ b/docs/2026-03-18_j4_go-no-go.md
@@ -1,15 +1,15 @@
 # Décision formelle Go/No-Go J4 PostgreSQL
 
 Date: 2026-03-18
-Statut: No-Go
+Statut: Go
 Périmètre: T-02 `TODO.md`
 Référence critères: `docs/phases/J4_MIGRATION.md`
 
 ## Décision
 
-Décision formelle au 2026-03-18: `No-Go` pour l'exécution J4 PostgreSQL.
+Décision formelle au 2026-03-18: `Go` pour l'exécution J4 PostgreSQL sur l'environnement de validation.
 
-La décision est `No-Go` car les critères `Go` de `docs/phases/J4_MIGRATION.md` sont cumulatifs, et plusieurs restent non démontrés ou invalidés dans l'état actuel du dépôt.
+La décision est `Go` car les critères `Go` de `docs/phases/J4_MIGRATION.md` sont désormais couverts par des preuves versionnées dans le dépôt.
 
 ## Évaluation des critères Go
 
@@ -55,7 +55,7 @@ Conclusion critère 3:
 
 ### 4. CI verte sur le backend `postgresql` (parcours de référence)
 
-Statut: Partiellement satisfait.
+Statut: Satisfait.
 
 Éléments disponibles:
 - Le workflow de référence existe: `.github/workflows/docker-stack.yml`.
@@ -63,12 +63,13 @@ Statut: Partiellement satisfait.
 - Vérification locale du parcours proche de la CI exécutée le 2026-03-18:
   - Commande: `pytest -q tests/test_api_fastapi.py tests/test_api_smoke_critical.py tests/test_db_backend_feature_flag.py`
   - Résultat: `33 passed`
-
-Éléments bloquants:
-- Aucun artefact versionné ne prouve un statut CI vert sur ce backend.
+- Vérification GitHub Actions sur la PR `#41`:
+  - Workflow `Docker Stack CI`: `pass`
+  - Job `api-tests-postgresql`: `pass`
+  - Preuve versionnée: `docs/artifacts/j4_ci_pr41_2026-03-18.json`
 
 Conclusion critère 4:
-- Non validé.
+- Validé.
 
 ## Synthèse Go/No-Go
 
@@ -76,23 +77,20 @@ Critères Go requis:
 - Critère 1: validé
 - Critère 2: validé
 - Critère 3: validé de manière dérogatoire
-- Critère 4: non validé
-
-Critères No-Go rencontrés:
-- CI non démontrée sur le backend PostgreSQL de référence
+- Critère 4: validé
 
 ## Décision retenue
 
-Décision finale: `No-Go`
+Décision finale: `Go`
 
-Cette décision interdit de considérer J4 comme prêt pour exécution contrôlée tant que les écarts suivants ne sont pas levés.
+J4 peut être considéré comme prêt pour exécution contrôlée sur la base des preuves disponibles au 2026-03-18.
 
 ## Écarts bloquants à corriger
 
-1. Capturer une preuve versionnée de CI verte sur le backend PostgreSQL de référence.
+1. Surveiller la reproductibilité de ces résultats sur l'environnement de référence cible.
 
 ## Recommandation opérationnelle
 
 Ordre de traitement recommandé:
-1. Archiver une preuve CI PostgreSQL verte.
-2. Refaire une décision formelle Go/No-Go après clôture de cet écart.
+1. Exécuter la bascule contrôlée selon le runbook J4.
+2. Conserver les artefacts de validation comme baseline de référence.

--- a/docs/artifacts/j4_ci_pr41_2026-03-18.json
+++ b/docs/artifacts/j4_ci_pr41_2026-03-18.json
@@ -1,0 +1,35 @@
+{
+  "timestamp_utc": "2026-03-18T12:29:00Z",
+  "repository": "lamacheref/openindex",
+  "pull_request": 41,
+  "pull_request_url": "https://github.com/lamacheref/openindex/pull/41",
+  "workflow": "Docker Stack CI",
+  "run_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250",
+  "checks": [
+    {
+      "name": "api-tests-postgresql",
+      "status": "pass",
+      "job_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250/job/67569806980"
+    },
+    {
+      "name": "changes",
+      "status": "pass",
+      "job_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250/job/67569806903"
+    },
+    {
+      "name": "docker-build-api",
+      "status": "pass",
+      "job_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250/job/67569826850"
+    },
+    {
+      "name": "docker-build-crawler",
+      "status": "pass",
+      "job_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250/job/67569826906"
+    },
+    {
+      "name": "docker-build-ui",
+      "status": "skipping",
+      "job_url": "https://github.com/lamacheref/openindex/actions/runs/23244669250/job/67569827387"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- finalize J4 go/no-go decision as Go after GitHub CI success
- add versioned CI evidence artifact for PR #41
- align execution report and TODO with final validation state

## Context
PR #41 delivered the technical remediation and passed  in GitHub Actions.
This follow-up PR only carries the final documentation state based on that completed CI run.