### PR TITLE
Embarquer les assets UI et retablir le websocket

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,19 @@
 # Dockerfile pour le service Frontend VanillaJS
+FROM node:22-alpine AS frontend-builder
+
+WORKDIR /build
+
+COPY package.json ./
+COPY tailwind.config.js ./
+RUN npm install
+
+COPY frontend/ ./frontend/
+RUN mkdir -p frontend/assets/fontawesome/css \
+    && npm run build:frontend \
+    && cp node_modules/alpinejs/dist/cdn.min.js frontend/assets/alpine.min.js \
+    && cp node_modules/@fortawesome/fontawesome-free/css/all.min.css frontend/assets/fontawesome/css/all.min.css \
+    && cp -R node_modules/@fortawesome/fontawesome-free/webfonts frontend/assets/fontawesome/
+
 FROM nginx:alpine
 
 # Métadonnées
@@ -12,7 +27,7 @@ RUN apk add --no-cache \
     && rm -rf /var/cache/apk/*
 
 # Copier les sources du frontend
-COPY frontend/ /usr/share/nginx/html/
+COPY --from=frontend-builder /build/frontend/ /usr/share/nginx/html/
 
 # Configuration Nginx optimisée
 COPY nginx/nginx.conf /etc/nginx/nginx.conf

--- a/frontend/favicon.svg
+++ b/frontend/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0f766e"/>
+  <path d="M16 18h15a8 8 0 0 1 7.2 4.5L40 26h8v20H16V18zm8 10v10h16V28H24z" fill="#f8fafc"/>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenIndex - Console opératoire</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
-    <script src="https://unpkg.com/htmx.org@1.9.6"></script>
-    <script src="https://unpkg.com/alpinejs@3.12.3/dist/cdn.min.js" defer></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="/assets/alpine.min.js" defer></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
+    <link rel="stylesheet" href="/assets/fontawesome/css/all.min.css">
 
     <style>
         .fade-in { animation: fadeIn 0.25s ease-in; }

--- a/frontend/styles/tailwind-input.css
+++ b/frontend/styles/tailwind-input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,8 +21,8 @@ http {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'" always;
 
         # Compression Gzip
         gzip on;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "openindex-frontend-build",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build:frontend": "tailwindcss -i ./frontend/styles/tailwind-input.css -o ./frontend/assets/tailwind.css --minify"
+  },
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "6.4.0",
+    "alpinejs": "3.12.3",
+    "tailwindcss": "3.4.17"
+  }
+}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110,<1.0
 uvicorn>=0.29,<1.0
+websockets>=12.0,<13.0
 pydantic>=2.6,<3.0
 starlette>=0.37,<1.0
 httpx>=0.27,<1.0

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    "./frontend/index.html"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tests/test_frontend_structure.py
+++ b/tests/test_frontend_structure.py
@@ -32,10 +32,12 @@ def test_frontend_has_expected_views_and_bindings():
 def test_frontend_uses_realtime_libs_and_fixed_header_shell():
     html = read_frontend_html()
 
-    assert "chart.js" in html.lower()
     assert "WebSocket" in html
     assert "fixed top-0 left-0 right-0" in html
     assert "overflow-y-auto" in html
+    assert "/assets/alpine.min.js" in html
+    assert "/assets/tailwind.css" in html
+    assert "/assets/fontawesome/css/all.min.css" in html
 
 
 def test_frontend_sidebar_contains_expected_operator_navigation():


### PR DESCRIPTION
## Objectif
- supprimer les dependances CDN en runtime pour l UI
- corriger le WebSocket du dashboard operatoire
- embarquer les assets frontend dans l image de production

## Contenu
- build local Tailwind dans l image frontend
- embarquement local de Alpine et Font Awesome
- ajout d un favicon
- ajustement des headers Nginx frontend
- ajout de websockets dans l image API pour supporter /ws
- alignement des tests frontend

## Verification locale
- pytest -q tests/test_frontend_structure.py tests/test_api_fastapi.py
- resultat: 19 passed, 1 warning
- verification manuelle: /api/system/status, /api/crawler/runtime et ws://localhost:3000/ws OK

## Hors scope
- docs/definition_ui.md non incluse
- artefact docs/artifacts/j4_cutover_openindex_2026-03-18.json non inclus